### PR TITLE
feat: implement admin panel with Authentik integration

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,9 @@
+# Authentik OpenID Connect configuration
+VITE_AUTHENTIK_ISSUER_URL=https://auth.example.com
+VITE_AUTHENTIK_CLIENT_ID=fromistargram-admin
+VITE_AUTHENTIK_REDIRECT_URI=http://localhost:5173/admin
+VITE_AUTHENTIK_LOGOUT_REDIRECT_URI=http://localhost:5173/admin
+VITE_AUTHENTIK_SCOPE=openid profile email roles
+VITE_AUTHENTIK_ADMIN_ROLE=admin
+# Optional: specify audience when Resource Server validation is enabled
+# VITE_AUTHENTIK_AUDIENCE=fromistargram-api

--- a/frontend/docs/authentik-setup.md
+++ b/frontend/docs/authentik-setup.md
@@ -1,0 +1,43 @@
+# Authentik 연동 가이드
+
+프런트엔드 어드민 패널은 Authentik OpenID Connect(OIDC) 애플리케이션과 연동하여 관리자 인증을 수행합니다. 다음 절차에 따라 환경 변수를 구성하고 리디렉트 경로를 등록하세요.
+
+## 1. Authentik OIDC 애플리케이션 생성
+1. Authentik 대시보드에서 **Applications → Create**를 선택합니다.
+2. `Protocol`을 **OAuth2/OpenID Provider**로 지정하고 `Client Type`은 **Public**으로 설정합니다.
+3. 생성된 애플리케이션의 **Client ID**와 **Issuer URL**(예: `https://auth.example.com`)을 확인합니다.
+4. **Redirect URIs**에 프런트엔드에서 사용할 주소를 추가합니다. 개발 환경에서는 `http://localhost:5173/admin`을 등록합니다.
+5. **Logout URIs**에는 로그아웃 후 돌아올 주소(예: `http://localhost:5173/admin`)를 추가합니다.
+6. `Scopes` 항목에 `openid profile email`과 같은 기본 범위를 포함하고, 역할 정보를 담는 커스텀 클레임을 추가했다면 해당 scope도 등록합니다.
+
+## 2. 역할(Claim) 매핑
+어드민 패널은 ID 토큰의 `roles` 클레임 안에 `admin` 문자열이 포함되어 있는지 검사합니다. Authentik의 **Policy → Property Mapping** 기능을 사용해 `roles` 배열에 운영자 권한을 주입하세요.
+
+예시 매핑:
+```json
+{
+  "roles": ["admin"]
+}
+```
+
+## 3. 환경 변수 설정
+프런트엔드 루트에 `.env` 파일을 생성하고 아래 값을 채웁니다. 기본 템플릿은 [`frontend/.env.example`](../.env.example)을 참고합니다.
+
+```bash
+VITE_AUTHENTIK_ISSUER_URL=https://auth.example.com
+VITE_AUTHENTIK_CLIENT_ID=fromistargram-admin
+VITE_AUTHENTIK_REDIRECT_URI=http://localhost:5173/admin
+VITE_AUTHENTIK_LOGOUT_REDIRECT_URI=http://localhost:5173/admin
+VITE_AUTHENTIK_SCOPE=openid profile email roles
+VITE_AUTHENTIK_ADMIN_ROLE=admin
+```
+
+필요 시 `VITE_AUTHENTIK_AUDIENCE` 값을 추가해 Authentik의 리소스 서버와 통신할 수 있습니다.
+
+## 4. 동작 확인
+1. `pnpm --filter @fromistargram/frontend dev` 명령으로 프런트엔드를 실행합니다.
+2. 브라우저에서 `/admin` 경로에 접속하면 Authentik 로그인 화면으로 리디렉션되는지 확인합니다.
+3. 로그인 후 토큰이 발급되면 어드민 대시보드가 노출됩니다.
+4. 로그아웃 버튼을 누르면 Authentik의 로그아웃 엔드포인트를 거쳐 다시 `/admin`으로 돌아옵니다.
+
+위 설정이 완료되면 어드민 패널은 Authentik 발급 토큰을 사용해 관리자 여부를 식별하고, 세션 상태를 브라우저 세션 스토리지에 안전하게 저장합니다.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,31 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
+import { AdminApiProvider } from './lib/api/admin/context';
 import { ApiClientProvider } from './lib/api/context';
+import { AuthProvider } from './lib/auth/context';
 import FeedPage from './routes/FeedPage';
+import AdminDashboard from './routes/admin/AdminDashboard';
+import AdminGate from './routes/admin/AdminGate';
+import AdminTargetsPage from './routes/admin/AdminTargetsPage';
+import AdminAccountsPage from './routes/admin/AdminAccountsPage';
+import AdminRunsPage from './routes/admin/AdminRunsPage';
 
 const App = () => (
   <ApiClientProvider>
-    <Routes>
-      <Route path="/" element={<FeedPage />} />
-      <Route path="/post/:postId" element={<FeedPage />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    <AuthProvider>
+      <AdminApiProvider>
+        <Routes>
+          <Route path="/" element={<FeedPage />} />
+          <Route path="/post/:postId" element={<FeedPage />} />
+          <Route path="/admin/*" element={<AdminGate />}> 
+            <Route index element={<AdminDashboard />} />
+            <Route path="targets" element={<AdminTargetsPage />} />
+            <Route path="accounts" element={<AdminAccountsPage />} />
+            <Route path="runs" element={<AdminRunsPage />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </AdminApiProvider>
+    </AuthProvider>
   </ApiClientProvider>
 );
 

--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -1,0 +1,79 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { useAuth } from '../../lib/auth/context';
+
+interface NavItem {
+  to: string;
+  label: string;
+  end?: boolean;
+}
+
+const navItems: NavItem[] = [
+  { to: '/admin', label: '대시보드', end: true },
+  { to: '/admin/targets', label: '크롤링 대상' },
+  { to: '/admin/accounts', label: '로그인 계정' },
+  { to: '/admin/runs', label: '실행 이력' }
+];
+
+interface AdminLayoutProps {
+  children?: ReactNode;
+}
+
+const AdminLayout = ({ children }: AdminLayoutProps) => {
+  const { idToken, logout } = useAuth();
+
+  return (
+    <div className="min-h-screen bg-slate-900 text-slate-100">
+      <header className="border-b border-slate-800 bg-slate-950/75 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-lg font-semibold text-brand-300">Fromistargram Admin</h1>
+            <p className="text-sm text-slate-400">
+              Authentik 연동된 운영자 전용 제어판
+            </p>
+          </div>
+          <div className="text-right text-sm">
+            <p className="font-medium">{idToken?.name ?? idToken?.username ?? '관리자'}</p>
+            <p className="text-xs text-slate-400">{idToken?.email ?? 'no-email@fromistargram'}</p>
+            <button
+              type="button"
+              onClick={logout}
+              className="mt-2 rounded border border-slate-700 px-3 py-1 text-xs text-slate-300 transition hover:border-brand-400 hover:text-brand-200"
+            >
+              로그아웃
+            </button>
+          </div>
+        </div>
+      </header>
+      <div className="mx-auto flex max-w-6xl gap-8 px-6 py-6">
+        <nav className="w-56 flex-shrink-0">
+          <ul className="space-y-2">
+            {navItems.map((item) => (
+              <li key={item.to}>
+                <NavLink
+                  to={item.to}
+                  end={item.end}
+                  className={({ isActive }) =>
+                    [
+                      'block rounded-md px-3 py-2 text-sm font-medium transition',
+                      isActive
+                        ? 'bg-brand-500/20 text-brand-200 shadow'
+                        : 'text-slate-300 hover:bg-slate-800 hover:text-slate-100'
+                    ].join(' ')
+                  }
+                >
+                  {item.label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <main className="flex-1 space-y-6 pb-12">
+          {children ?? <Outlet />}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/frontend/src/components/admin/AdminSectionCard.tsx
+++ b/frontend/src/components/admin/AdminSectionCard.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+interface AdminSectionCardProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}
+
+const AdminSectionCard = ({ title, description, actions, children }: AdminSectionCardProps) => (
+  <section className="rounded-xl border border-slate-800 bg-slate-900/60 shadow-lg shadow-slate-900/40">
+    <header className="flex items-start justify-between border-b border-slate-800 px-5 py-4">
+      <div>
+        <h2 className="text-base font-semibold text-slate-100">{title}</h2>
+        {description ? (
+          <p className="mt-1 text-sm text-slate-400">{description}</p>
+        ) : null}
+      </div>
+      {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+    </header>
+    <div className="px-5 py-4 text-sm text-slate-200">{children}</div>
+  </section>
+);
+
+export default AdminSectionCard;

--- a/frontend/src/hooks/admin/useCrawlAccounts.ts
+++ b/frontend/src/hooks/admin/useCrawlAccounts.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAdminApi } from '../../lib/api/admin/context';
+import type {
+  CrawlAccount,
+  CrawlAccountPatch,
+  CrawlAccountPayload
+} from '../../lib/api/admin/types';
+
+const ACCOUNTS_KEY = ['admin', 'accounts'];
+
+export const useCrawlAccounts = () => {
+  const client = useAdminApi();
+  const query = useQuery({
+    queryKey: ACCOUNTS_KEY,
+    queryFn: () => client.listAccounts()
+  });
+
+  return {
+    ...query,
+    accounts: query.data ?? []
+  };
+};
+
+export const useCreateAccount = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CrawlAccountPayload) => client.createAccount(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACCOUNTS_KEY });
+    }
+  });
+};
+
+export const useUpdateAccount = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: CrawlAccountPatch }) =>
+      client.updateAccount(id, patch),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACCOUNTS_KEY });
+    }
+  });
+};
+
+export const useDeleteAccount = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => client.deleteAccount(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACCOUNTS_KEY });
+    }
+  });
+};
+
+export const useRegisterSession = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, sessionId }: { id: string; sessionId: string }) =>
+      client.registerSession(id, sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACCOUNTS_KEY });
+    }
+  });
+};
+
+export type { CrawlAccount };

--- a/frontend/src/hooks/admin/useCrawlRuns.ts
+++ b/frontend/src/hooks/admin/useCrawlRuns.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAdminApi } from '../../lib/api/admin/context';
+import type { CrawlRun, ManualRunPayload } from '../../lib/api/admin/types';
+
+const RUNS_KEY = ['admin', 'runs'];
+
+export const useCrawlRuns = () => {
+  const client = useAdminApi();
+  const query = useQuery({
+    queryKey: RUNS_KEY,
+    queryFn: () => client.listRuns()
+  });
+
+  return {
+    ...query,
+    runs: query.data ?? []
+  };
+};
+
+export const useTriggerRun = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: ManualRunPayload) => client.triggerRun(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: RUNS_KEY });
+    }
+  });
+};
+
+export type { CrawlRun };

--- a/frontend/src/hooks/admin/useCrawlTargets.ts
+++ b/frontend/src/hooks/admin/useCrawlTargets.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAdminApi } from '../../lib/api/admin/context';
+import type {
+  CrawlTarget,
+  CrawlTargetPatch,
+  CrawlTargetPayload
+} from '../../lib/api/admin/types';
+
+const TARGETS_KEY = ['admin', 'targets'];
+
+export const useCrawlTargets = () => {
+  const client = useAdminApi();
+
+  const query = useQuery({
+    queryKey: TARGETS_KEY,
+    queryFn: () => client.listTargets()
+  });
+
+  return {
+    ...query,
+    targets: query.data ?? []
+  };
+};
+
+export const useCreateTarget = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CrawlTargetPayload) => client.createTarget(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TARGETS_KEY });
+    }
+  });
+};
+
+export const useUpdateTarget = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: CrawlTargetPatch }) =>
+      client.updateTarget(id, patch),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TARGETS_KEY });
+    }
+  });
+};
+
+export const useDeleteTarget = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => client.deleteTarget(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TARGETS_KEY });
+    }
+  });
+};
+
+export const useReorderTargets = () => {
+  const client = useAdminApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (ids: string[]) => client.reorderTargets(ids),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: TARGETS_KEY });
+    }
+  });
+};
+
+export type { CrawlTarget };

--- a/frontend/src/hooks/admin/useFeedStatistics.ts
+++ b/frontend/src/hooks/admin/useFeedStatistics.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAdminApi } from '../../lib/api/admin/context';
+import type { FeedStatistics } from '../../lib/api/admin/types';
+
+const STATS_KEY = ['admin', 'feed-stats'];
+
+export const useFeedStatistics = () => {
+  const client = useAdminApi();
+  const query = useQuery({
+    queryKey: STATS_KEY,
+    queryFn: () => client.fetchFeedStatistics(),
+    refetchInterval: 1000 * 60 * 5
+  });
+
+  return {
+    ...query,
+    statistics: query.data ?? null
+  };
+};
+
+export type { FeedStatistics };

--- a/frontend/src/lib/api/admin/context.tsx
+++ b/frontend/src/lib/api/admin/context.tsx
@@ -1,0 +1,26 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type ReactNode
+} from 'react';
+import { createMockAdminApiClient } from './mockData';
+import type { AdminApiClient } from './types';
+
+const AdminApiContext = createContext<AdminApiClient | null>(null);
+
+export const AdminApiProvider = ({ children }: { children: ReactNode }) => {
+  const client = useMemo(() => createMockAdminApiClient(), []);
+
+  return (
+    <AdminApiContext.Provider value={client}>{children}</AdminApiContext.Provider>
+  );
+};
+
+export const useAdminApi = (): AdminApiClient => {
+  const client = useContext(AdminApiContext);
+  if (!client) {
+    throw new Error('useAdminApi must be used within AdminApiProvider');
+  }
+  return client;
+};

--- a/frontend/src/lib/api/admin/mockData.ts
+++ b/frontend/src/lib/api/admin/mockData.ts
@@ -1,0 +1,270 @@
+import {
+  type AdminApiClient,
+  type CrawlAccount,
+  type CrawlAccountPatch,
+  type CrawlAccountPayload,
+  type CrawlRun,
+  type CrawlTarget,
+  type CrawlTargetPatch,
+  type CrawlTargetPayload,
+  type FeedStatistics,
+  type ManualRunPayload
+} from './types';
+
+let targets: CrawlTarget[] = [
+  {
+    id: 'tgt_1',
+    handle: 'fromis_9',
+    displayName: 'fromis_9',
+    isActive: true,
+    isFeatured: true,
+    priority: 1,
+    lastSyncedAt: new Date(Date.now() - 1000 * 60 * 15).toISOString(),
+    postCount: 245
+  },
+  {
+    id: 'tgt_2',
+    handle: 'saerom',
+    displayName: 'Lee Sae-rom',
+    isActive: true,
+    isFeatured: true,
+    priority: 2,
+    lastSyncedAt: new Date(Date.now() - 1000 * 60 * 55).toISOString(),
+    postCount: 120
+  },
+  {
+    id: 'tgt_3',
+    handle: 'jiwon',
+    displayName: 'Park Ji-won',
+    isActive: false,
+    isFeatured: false,
+    priority: 3,
+    lastSyncedAt: null,
+    postCount: 64
+  }
+];
+
+let accounts: CrawlAccount[] = [
+  {
+    id: 'acc_1',
+    username: 'crawler_main',
+    status: 'ready',
+    lastSessionAt: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
+    note: 'Primary production session'
+  },
+  {
+    id: 'acc_2',
+    username: 'crawler_backup',
+    status: 'disabled',
+    lastSessionAt: null,
+    note: 'Use when primary is throttled'
+  }
+];
+
+let runs: CrawlRun[] = [
+  {
+    id: 'run_1',
+    targetId: 'tgt_1',
+    targetHandle: 'fromis_9',
+    triggeredBy: 'system',
+    sessionId: 'session_main',
+    startedAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+    finishedAt: new Date(Date.now() - 1000 * 60 * 48).toISOString(),
+    status: 'success'
+  },
+  {
+    id: 'run_2',
+    targetId: 'tgt_2',
+    targetHandle: 'saerom',
+    triggeredBy: 'admin@fromistargram',
+    sessionId: 'session_manual_01',
+    startedAt: new Date(Date.now() - 1000 * 60 * 180).toISOString(),
+    finishedAt: new Date(Date.now() - 1000 * 60 * 170).toISOString(),
+    status: 'failure',
+    message: 'HTTP 429 rate limited'
+  }
+];
+
+const delay = async <T>(value: T, ms = 80): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+const normalizePriority = () => {
+  targets = targets
+    .sort((a, b) => a.priority - b.priority)
+    .map((target, index) => ({ ...target, priority: index + 1 }));
+};
+
+const computeStatistics = (): FeedStatistics => {
+  const totalTargets = targets.length;
+  const activeTargets = targets.filter((target) => target.isActive).length;
+  const featuredTargets = targets.filter((target) => target.isFeatured).length;
+  const totalPosts = targets.reduce((acc, target) => acc + target.postCount, 0);
+  const lastIndexedAt = targets
+    .map((target) => target.lastSyncedAt)
+    .filter((value): value is string => Boolean(value))
+    .sort()
+    .at(-1) ?? null;
+
+  return {
+    totalTargets,
+    activeTargets,
+    featuredTargets,
+    totalPosts,
+    lastIndexedAt
+  };
+};
+
+const generateId = (prefix: string) => `${prefix}_${crypto.randomUUID()}`;
+
+export const createMockAdminApiClient = (): AdminApiClient => ({
+  async listTargets() {
+    normalizePriority();
+    return delay([...targets]);
+  },
+  async createTarget(payload) {
+    const newTarget: CrawlTarget = {
+      id: generateId('tgt'),
+      handle: payload.handle,
+      displayName: payload.displayName,
+      isActive: payload.isActive ?? true,
+      isFeatured: payload.isFeatured ?? false,
+      priority: targets.length + 1,
+      lastSyncedAt: null,
+      postCount: 0
+    };
+    targets = [...targets, newTarget];
+    return delay(newTarget);
+  },
+  async updateTarget(id, patch) {
+    targets = targets.map((target) =>
+      target.id === id
+        ? {
+            ...target,
+            ...patch
+          }
+        : target
+    );
+    normalizePriority();
+    const updated = targets.find((target) => target.id === id);
+    if (!updated) {
+      throw new Error('Target not found');
+    }
+    return delay(updated);
+  },
+  async deleteTarget(id) {
+    targets = targets.filter((target) => target.id !== id);
+    normalizePriority();
+    return delay(undefined);
+  },
+  async reorderTargets(idsInOrder) {
+    const map = new Map(targets.map((target) => [target.id, target] as const));
+    const ordered: CrawlTarget[] = [];
+    idsInOrder.forEach((id, index) => {
+      const found = map.get(id);
+      if (found) {
+        ordered.push({ ...found, priority: index + 1 });
+        map.delete(id);
+      }
+    });
+
+    const remaining = Array.from(map.values()).sort((a, b) => a.priority - b.priority);
+    targets = [...ordered, ...remaining].map((target, index) => ({
+      ...target,
+      priority: index + 1
+    }));
+    return delay([...targets]);
+  },
+  async listAccounts() {
+    return delay([...accounts]);
+  },
+  async createAccount(payload: CrawlAccountPayload) {
+    const account: CrawlAccount = {
+      id: generateId('acc'),
+      username: payload.username,
+      status: 'ready',
+      lastSessionAt: null,
+      note: payload.note
+    };
+    accounts = [...accounts, account];
+    return delay(account);
+  },
+  async updateAccount(id: string, patch: CrawlAccountPatch) {
+    accounts = accounts.map((account) =>
+      account.id === id
+        ? {
+            ...account,
+            ...patch
+          }
+        : account
+    );
+    const updated = accounts.find((account) => account.id === id);
+    if (!updated) {
+      throw new Error('Account not found');
+    }
+    return delay(updated);
+  },
+  async deleteAccount(id: string) {
+    accounts = accounts.filter((account) => account.id !== id);
+    return delay(undefined);
+  },
+  async registerSession(id: string, sessionId: string) {
+    const now = new Date().toISOString();
+    accounts = accounts.map((account) =>
+      account.id === id
+        ? {
+            ...account,
+            lastSessionAt: now,
+            status: 'ready',
+            note: account.note
+          }
+        : account
+    );
+
+    runs = [
+      {
+        id: generateId('run'),
+        targetId: 'manual',
+        targetHandle: 'manual',
+        triggeredBy: 'admin',
+        sessionId,
+        startedAt: now,
+        finishedAt: now,
+        status: 'success'
+      },
+      ...runs
+    ];
+
+    const updated = accounts.find((account) => account.id === id);
+    if (!updated) {
+      throw new Error('Account not found');
+    }
+
+    return delay(updated);
+  },
+  async listRuns() {
+    return delay([...runs]);
+  },
+  async triggerRun(payload: ManualRunPayload) {
+    const target = targets.find((item) => item.id === payload.targetId);
+    if (!target) {
+      throw new Error('Target not found');
+    }
+
+    const run: CrawlRun = {
+      id: generateId('run'),
+      targetId: target.id,
+      targetHandle: target.handle,
+      triggeredBy: 'admin',
+      sessionId: payload.sessionId,
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      status: 'queued'
+    };
+
+    runs = [run, ...runs];
+    return delay(run);
+  },
+  async fetchFeedStatistics() {
+    return delay(computeStatistics());
+  }
+});

--- a/frontend/src/lib/api/admin/types.ts
+++ b/frontend/src/lib/api/admin/types.ts
@@ -1,0 +1,84 @@
+export interface CrawlTarget {
+  id: string;
+  handle: string;
+  displayName: string;
+  isActive: boolean;
+  isFeatured: boolean;
+  priority: number;
+  lastSyncedAt: string | null;
+  postCount: number;
+}
+
+export interface CrawlTargetPayload {
+  handle: string;
+  displayName: string;
+  isActive?: boolean;
+  isFeatured?: boolean;
+}
+
+export interface CrawlTargetPatch {
+  displayName?: string;
+  isActive?: boolean;
+  isFeatured?: boolean;
+  priority?: number;
+}
+
+export interface CrawlAccount {
+  id: string;
+  username: string;
+  status: 'ready' | 'error' | 'disabled';
+  lastSessionAt: string | null;
+  note?: string;
+}
+
+export interface CrawlAccountPayload {
+  username: string;
+  note?: string;
+}
+
+export interface CrawlAccountPatch {
+  username?: string;
+  note?: string;
+  status?: CrawlAccount['status'];
+}
+
+export interface CrawlRun {
+  id: string;
+  targetId: string;
+  targetHandle: string;
+  triggeredBy: string;
+  sessionId: string;
+  startedAt: string;
+  finishedAt: string | null;
+  status: 'queued' | 'running' | 'success' | 'failure';
+  message?: string;
+}
+
+export interface ManualRunPayload {
+  targetId: string;
+  sessionId: string;
+}
+
+export interface FeedStatistics {
+  totalTargets: number;
+  activeTargets: number;
+  featuredTargets: number;
+  totalPosts: number;
+  lastIndexedAt: string | null;
+}
+
+export interface AdminApiClient {
+  listTargets(): Promise<CrawlTarget[]>;
+  createTarget(payload: CrawlTargetPayload): Promise<CrawlTarget>;
+  updateTarget(id: string, patch: CrawlTargetPatch): Promise<CrawlTarget>;
+  deleteTarget(id: string): Promise<void>;
+  reorderTargets(idsInOrder: string[]): Promise<CrawlTarget[]>;
+  listAccounts(): Promise<CrawlAccount[]>;
+  createAccount(payload: CrawlAccountPayload): Promise<CrawlAccount>;
+  updateAccount(id: string, patch: CrawlAccountPatch): Promise<CrawlAccount>;
+  deleteAccount(id: string): Promise<void>;
+  registerSession(id: string, sessionId: string): Promise<CrawlAccount>;
+  listRuns(): Promise<CrawlRun[]>;
+  triggerRun(payload: ManualRunPayload): Promise<CrawlRun>;
+  fetchFeedStatistics(): Promise<FeedStatistics>;
+}

--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -1,0 +1,56 @@
+export interface AuthentikConfig {
+  issuerUrl: string;
+  clientId: string;
+  redirectUri: string;
+  scope: string;
+  adminRole: string;
+  audience?: string;
+  logoutRedirectUri?: string;
+}
+
+const requiredEnv = [
+  'VITE_AUTHENTIK_ISSUER_URL',
+  'VITE_AUTHENTIK_CLIENT_ID',
+  'VITE_AUTHENTIK_REDIRECT_URI',
+  'VITE_AUTHENTIK_SCOPE',
+  'VITE_AUTHENTIK_ADMIN_ROLE'
+] as const;
+
+type RequiredEnvKey = (typeof requiredEnv)[number];
+
+const getEnv = (key: RequiredEnvKey): string => {
+  const value = import.meta.env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+};
+
+export const loadAuthentikConfig = (): AuthentikConfig => {
+  const [
+    issuerUrl,
+    clientId,
+    redirectUri,
+    scope,
+    adminRole
+  ] = requiredEnv.map((key) => getEnv(key));
+
+  const optional: Partial<AuthentikConfig> = {};
+
+  if (import.meta.env.VITE_AUTHENTIK_AUDIENCE) {
+    optional.audience = import.meta.env.VITE_AUTHENTIK_AUDIENCE;
+  }
+
+  if (import.meta.env.VITE_AUTHENTIK_LOGOUT_REDIRECT_URI) {
+    optional.logoutRedirectUri = import.meta.env.VITE_AUTHENTIK_LOGOUT_REDIRECT_URI;
+  }
+
+  return {
+    issuerUrl,
+    clientId,
+    redirectUri,
+    scope,
+    adminRole,
+    ...optional
+  };
+};

--- a/frontend/src/lib/auth/context.tsx
+++ b/frontend/src/lib/auth/context.tsx
@@ -1,0 +1,321 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react';
+import { loadAuthentikConfig, type AuthentikConfig } from './config';
+import {
+  decodeJwt,
+  isTokenExpired,
+  parseIdToken,
+  type ParsedIdToken
+} from './token';
+
+type TokenResponse = {
+  access_token: string;
+  id_token: string;
+  expires_in?: number;
+  token_type?: string;
+  scope?: string;
+  state?: string;
+};
+
+type StoredSession = {
+  accessToken: string;
+  idToken: string;
+  expiresAt: number;
+  scope?: string;
+  tokenType?: string;
+};
+
+export interface AuthContextValue {
+  config: AuthentikConfig;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  token: string | null;
+  idToken: ParsedIdToken | null;
+  login: (options?: { prompt?: 'login' | 'consent'; force?: boolean }) => void;
+  logout: () => void;
+  hasAdminRole: boolean;
+  error: string | null;
+}
+
+const STORAGE_KEY = 'fromistargram.auth.session';
+const STATE_KEY = 'fromistargram.auth.state';
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+const parseHashParams = (hash: string): URLSearchParams => {
+  const trimmed = hash.startsWith('#') ? hash.slice(1) : hash;
+  return new URLSearchParams(trimmed);
+};
+
+const resolveExpiresAt = (token: string, expiresIn?: number): number => {
+  if (typeof expiresIn === 'number' && Number.isFinite(expiresIn)) {
+    return Date.now() + expiresIn * 1000;
+  }
+
+  const payload = decodeJwt(token);
+  if (!payload?.exp) {
+    return Date.now();
+  }
+
+  return payload.exp * 1000;
+};
+
+const tryParseTokenResponse = (hash: string): TokenResponse | null => {
+  if (!hash) {
+    return null;
+  }
+
+  const params = parseHashParams(hash);
+  const accessToken = params.get('access_token');
+  const idToken = params.get('id_token');
+
+  if (!accessToken || !idToken) {
+    return null;
+  }
+
+  const expiresInRaw = params.get('expires_in');
+  const expiresIn = expiresInRaw ? Number.parseInt(expiresInRaw, 10) : undefined;
+
+  return {
+    access_token: accessToken,
+    id_token: idToken,
+    expires_in: Number.isNaN(expiresIn) ? undefined : expiresIn,
+    token_type: params.get('token_type') ?? undefined,
+    scope: params.get('scope') ?? undefined,
+    state: params.get('state') ?? undefined
+  };
+};
+
+const loadStoredSession = (): StoredSession | null => {
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as StoredSession;
+    if (!parsed.accessToken || !parsed.idToken || !parsed.expiresAt) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.error('Failed to parse stored session', error);
+    sessionStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+};
+
+const persistSession = (session: StoredSession | null) => {
+  if (!session) {
+    sessionStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+};
+
+const generateState = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return Math.random().toString(36).slice(2, 10);
+};
+
+const buildAuthorizeUrl = (config: AuthentikConfig, state: string) => {
+  const params = new URLSearchParams({
+    response_type: 'id_token token',
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: config.scope,
+    state
+  });
+
+  if (config.audience) {
+    params.set('audience', config.audience);
+  }
+
+  return `${config.issuerUrl.replace(/\/$/, '')}/application/o/authorize/?${params.toString()}`;
+};
+
+const buildLogoutUrl = (config: AuthentikConfig, redirectUri: string) => {
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    post_logout_redirect_uri: redirectUri
+  });
+
+  return `${config.issuerUrl.replace(/\/$/, '')}/application/o/logout/?${params.toString()}`;
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const configRef = useRef<AuthentikConfig | null>(null);
+  const [state, setState] = useState<{
+    token: string | null;
+    idToken: ParsedIdToken | null;
+    expiresAt: number | null;
+    isLoading: boolean;
+    error: string | null;
+  }>({
+    token: null,
+    idToken: null,
+    expiresAt: null,
+    isLoading: true,
+    error: null
+  });
+
+  if (!configRef.current) {
+    configRef.current = loadAuthentikConfig();
+  }
+
+  const config = configRef.current;
+
+  const logout = useCallback(() => {
+    persistSession(null);
+    setState((prev) => ({
+      ...prev,
+      token: null,
+      idToken: null,
+      expiresAt: null
+    }));
+
+    const redirectUri = config.logoutRedirectUri ?? config.redirectUri;
+    const logoutUrl = buildLogoutUrl(config, redirectUri);
+    window.location.assign(logoutUrl);
+  }, [config]);
+
+  const login = useCallback(
+    (options?: { prompt?: 'login' | 'consent'; force?: boolean }) => {
+      const stateValue = generateState();
+      const authorizeUrl = new URL(buildAuthorizeUrl(config, stateValue));
+
+      if (options?.prompt) {
+        authorizeUrl.searchParams.set('prompt', options.prompt);
+      }
+
+      if (options?.force) {
+        authorizeUrl.searchParams.set('max_age', '0');
+      }
+
+      sessionStorage.setItem(STATE_KEY, stateValue);
+      window.location.assign(authorizeUrl.toString());
+    },
+    [config]
+  );
+
+  useEffect(() => {
+    const hashResponse = tryParseTokenResponse(window.location.hash);
+
+    if (hashResponse) {
+      const stateValue = sessionStorage.getItem(STATE_KEY);
+      if (hashResponse.state && hashResponse.state !== stateValue) {
+        setState((prev) => ({
+          ...prev,
+          error: '인증 상태값이 일치하지 않습니다.',
+          isLoading: false
+        }));
+        return;
+      }
+
+      const expiresAt = resolveExpiresAt(hashResponse.id_token, hashResponse.expires_in);
+
+      const session: StoredSession = {
+        accessToken: hashResponse.access_token,
+        idToken: hashResponse.id_token,
+        expiresAt,
+        scope: hashResponse.scope,
+        tokenType: hashResponse.token_type
+      };
+
+      persistSession(session);
+      sessionStorage.removeItem(STATE_KEY);
+      window.history.replaceState({}, document.title, window.location.pathname + window.location.search);
+      const parsed = parseIdToken(hashResponse.id_token);
+      setState({
+        token: hashResponse.access_token,
+        idToken: parsed,
+        expiresAt,
+        isLoading: false,
+        error: null
+      });
+      return;
+    }
+
+    const stored = loadStoredSession();
+
+    if (!stored || stored.expiresAt <= Date.now() || isTokenExpired(stored.idToken)) {
+      persistSession(null);
+      setState((prev) => ({ ...prev, isLoading: false }));
+      return;
+    }
+
+    const parsed = parseIdToken(stored.idToken);
+    if (!parsed) {
+      persistSession(null);
+      setState((prev) => ({ ...prev, isLoading: false }));
+      return;
+    }
+
+    setState({
+      token: stored.accessToken,
+      idToken: parsed,
+      expiresAt: stored.expiresAt,
+      isLoading: false,
+      error: null
+    });
+  }, []);
+
+  const hasAdminRole = useMemo(() => {
+    if (!state.idToken) {
+      return false;
+    }
+
+    const normalizedRoles = state.idToken.roles.map((role) => role.toLowerCase());
+    return normalizedRoles.includes(config.adminRole.toLowerCase());
+  }, [state.idToken, config.adminRole]);
+
+  const isAuthenticated = useMemo(() => {
+    if (!state.token || !state.idToken || !state.expiresAt) {
+      return false;
+    }
+
+    if (state.expiresAt <= Date.now()) {
+      return false;
+    }
+
+    return !isTokenExpired(state.idToken.raw);
+  }, [state.token, state.idToken, state.expiresAt]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      config,
+      isLoading: state.isLoading,
+      isAuthenticated,
+      token: state.token,
+      idToken: state.idToken,
+      login,
+      logout,
+      hasAdminRole,
+      error: state.error
+    }),
+    [config, state, isAuthenticated, login, logout, hasAdminRole]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+
+  return context;
+};

--- a/frontend/src/lib/auth/token.ts
+++ b/frontend/src/lib/auth/token.ts
@@ -1,0 +1,79 @@
+interface JwtPayload {
+  exp?: number;
+  iat?: number;
+  sub?: string;
+  email?: string;
+  name?: string;
+  preferred_username?: string;
+  roles?: string[];
+  [key: string]: unknown;
+}
+
+const decodeBase64Url = (value: string): string => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(normalized.length + (4 - (normalized.length % 4)) % 4, '=');
+  return atob(padded);
+};
+
+export const decodeJwt = <T extends JwtPayload = JwtPayload>(token: string): T | null => {
+  if (!token) {
+    return null;
+  }
+
+  const segments = token.split('.');
+  if (segments.length < 2) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(decodeBase64Url(segments[1]));
+    return payload as T;
+  } catch (error) {
+    console.error('Failed to decode JWT payload', error);
+    return null;
+  }
+};
+
+export const isTokenExpired = (token: string | null, clockToleranceSeconds = 30): boolean => {
+  if (!token) {
+    return true;
+  }
+
+  const payload = decodeJwt(token);
+  if (!payload?.exp) {
+    return true;
+  }
+
+  const nowSeconds = Date.now() / 1000;
+  return payload.exp < nowSeconds - clockToleranceSeconds;
+};
+
+export interface ParsedIdToken {
+  subject: string;
+  email?: string;
+  name?: string;
+  username?: string;
+  roles: string[];
+  raw: string;
+}
+
+export const parseIdToken = (token: string): ParsedIdToken | null => {
+  const payload = decodeJwt(token);
+  if (!payload?.sub) {
+    return null;
+  }
+
+  return {
+    subject: payload.sub,
+    email: typeof payload.email === 'string' ? payload.email : undefined,
+    name: typeof payload.name === 'string' ? payload.name : undefined,
+    username:
+      typeof payload.preferred_username === 'string'
+        ? payload.preferred_username
+        : undefined,
+    roles: Array.isArray(payload.roles)
+      ? payload.roles.filter((role): role is string => typeof role === 'string')
+      : [],
+    raw: token
+  };
+};

--- a/frontend/src/lib/auth/useAuthGuard.ts
+++ b/frontend/src/lib/auth/useAuthGuard.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useAuth } from './context';
+
+export const useAuthGuard = () => {
+  const auth = useAuth();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (auth.isLoading) {
+      return;
+    }
+
+    if (!auth.isAuthenticated || !auth.hasAdminRole) {
+      auth.login({ force: true });
+    }
+  }, [auth, location]);
+
+  return {
+    isLoading: auth.isLoading,
+    isAuthenticated: auth.isAuthenticated,
+    hasAdminRole: auth.hasAdminRole,
+    error: auth.error
+  };
+};

--- a/frontend/src/routes/admin/AdminAccountsPage.tsx
+++ b/frontend/src/routes/admin/AdminAccountsPage.tsx
@@ -1,0 +1,232 @@
+import { FormEvent, useMemo, useState } from 'react';
+import AdminSectionCard from '../../components/admin/AdminSectionCard';
+import {
+  useCreateAccount,
+  useCrawlAccounts,
+  useDeleteAccount,
+  useRegisterSession,
+  useUpdateAccount
+} from '../../hooks/admin/useCrawlAccounts';
+
+interface AccountFormState {
+  username: string;
+  note: string;
+}
+
+const initialAccountForm: AccountFormState = {
+  username: '',
+  note: ''
+};
+
+const AdminAccountsPage = () => {
+  const { accounts, isPending } = useCrawlAccounts();
+  const createAccount = useCreateAccount();
+  const updateAccount = useUpdateAccount();
+  const deleteAccount = useDeleteAccount();
+  const registerSession = useRegisterSession();
+  const [form, setForm] = useState<AccountFormState>(initialAccountForm);
+  const [sessionInput, setSessionInput] = useState<Record<string, string>>({});
+  const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({});
+
+  const sortedAccounts = useMemo(
+    () => [...accounts].sort((a, b) => a.username.localeCompare(b.username)),
+    [accounts]
+  );
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!form.username.trim()) {
+      return;
+    }
+
+    createAccount.mutate(form, {
+      onSuccess: () => setForm(initialAccountForm)
+    });
+  };
+
+  const handleStatusChange = (id: string, status: 'ready' | 'error' | 'disabled') => {
+    updateAccount.mutate({ id, patch: { status } });
+  };
+
+  const handleSessionSubmit = (id: string, sessionId: string) => {
+    if (!sessionId.trim()) {
+      return;
+    }
+
+    registerSession.mutate({ id, sessionId }, {
+      onSuccess: () =>
+        setSessionInput((prev) => ({
+          ...prev,
+          [id]: ''
+        }))
+    });
+  };
+
+  const handleNoteSave = (id: string) => {
+    const draft = noteDrafts[id];
+    updateAccount.mutate({
+      id,
+      patch: {
+        note: draft ?? ''
+      }
+    });
+  };
+
+  const resolveNoteDraft = (id: string, fallback?: string | null) => {
+    const draft = noteDrafts[id];
+    if (draft !== undefined) {
+      return draft;
+    }
+    return fallback ?? '';
+  };
+
+  return (
+    <div className="space-y-6">
+      <AdminSectionCard
+        title="로그인 계정 등록"
+        description="instaloader 세션 생성을 위한 인증 계정을 관리합니다."
+      >
+        <form onSubmit={handleSubmit} className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+              Instagram 로그인 ID
+            </span>
+            <input
+              className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 focus:border-brand-400 focus:outline-none"
+              value={form.username}
+              onChange={(event) => setForm((prev) => ({ ...prev, username: event.target.value }))}
+              placeholder="crawler_main"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+              비고
+            </span>
+            <input
+              className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 focus:border-brand-400 focus:outline-none"
+              value={form.note}
+              onChange={(event) => setForm((prev) => ({ ...prev, note: event.target.value }))}
+              placeholder="2FA 토큰 위치 등"
+            />
+          </label>
+          <div className="col-span-full">
+            <button
+              type="submit"
+              className="rounded bg-brand-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-brand-400"
+              disabled={createAccount.isPending}
+            >
+              계정 추가
+            </button>
+          </div>
+        </form>
+      </AdminSectionCard>
+
+      <AdminSectionCard
+        title="등록된 로그인 계정"
+        description="세션 갱신 및 상태 전환을 통해 크롤러 실행 계정을 유지합니다."
+      >
+        {isPending ? (
+          <p className="text-sm text-slate-400">계정 정보를 불러오는 중입니다…</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-800 text-sm">
+              <thead className="bg-slate-900/50 text-xs uppercase tracking-wide text-slate-400">
+                <tr>
+                  <th className="px-4 py-2 text-left">로그인 ID</th>
+                  <th className="px-4 py-2 text-left">상태</th>
+                  <th className="px-4 py-2 text-left">최근 세션 갱신</th>
+                  <th className="px-4 py-2 text-left">비고</th>
+                  <th className="px-4 py-2 text-right">관리</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-800">
+                {sortedAccounts.map((account) => (
+                  <tr key={account.id} className="hover:bg-slate-900/70">
+                    <td className="px-4 py-3 font-mono text-slate-100">{account.username}</td>
+                    <td className="px-4 py-3 text-slate-200">
+                      <select
+                        className="rounded border border-slate-700 bg-slate-950 px-2 py-1 text-xs"
+                        value={account.status}
+                        onChange={(event) =>
+                          handleStatusChange(
+                            account.id,
+                            event.target.value as 'ready' | 'error' | 'disabled'
+                          )
+                        }
+                      >
+                        <option value="ready">정상</option>
+                        <option value="error">오류</option>
+                        <option value="disabled">비활성</option>
+                      </select>
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">
+                      {account.lastSessionAt
+                        ? new Date(account.lastSessionAt).toLocaleString()
+                        : '기록 없음'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">
+                      <textarea
+                        className="h-16 w-full rounded border border-slate-700 bg-slate-950 px-2 py-1 text-xs text-slate-100"
+                        value={resolveNoteDraft(account.id, account.note)}
+                        onChange={(event) =>
+                          setNoteDrafts((prev) => ({
+                            ...prev,
+                            [account.id]: event.target.value
+                          }))
+                        }
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex flex-col items-end gap-2">
+                        <div className="flex items-center gap-2">
+                          <input
+                            className="w-40 rounded border border-slate-700 bg-slate-950 px-2 py-1 text-xs"
+                            placeholder="sessionid=..."
+                            value={sessionInput[account.id] ?? ''}
+                            onChange={(event) =>
+                              setSessionInput((prev) => ({
+                                ...prev,
+                                [account.id]: event.target.value
+                              }))
+                            }
+                          />
+                          <button
+                            type="button"
+                            className="rounded border border-brand-400/80 px-3 py-1 text-xs text-brand-200 hover:border-brand-300"
+                            onClick={() =>
+                              handleSessionSubmit(account.id, sessionInput[account.id] ?? '')
+                            }
+                          >
+                            세션 등록
+                          </button>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => handleNoteSave(account.id)}
+                            className="rounded border border-slate-700 px-3 py-1 text-xs hover:border-slate-500"
+                          >
+                            비고 저장
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => deleteAccount.mutate(account.id)}
+                            className="rounded border border-red-600/70 px-3 py-1 text-xs text-red-300 hover:border-red-500"
+                          >
+                            삭제
+                          </button>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </AdminSectionCard>
+    </div>
+  );
+};
+
+export default AdminAccountsPage;

--- a/frontend/src/routes/admin/AdminDashboard.tsx
+++ b/frontend/src/routes/admin/AdminDashboard.tsx
@@ -1,0 +1,157 @@
+import { useMemo, useState } from 'react';
+import AdminSectionCard from '../../components/admin/AdminSectionCard';
+import { useFeedStatistics } from '../../hooks/admin/useFeedStatistics';
+import {
+  useCrawlTargets,
+  useReorderTargets
+} from '../../hooks/admin/useCrawlTargets';
+
+const AdminDashboard = () => {
+  const { statistics } = useFeedStatistics();
+  const { targets } = useCrawlTargets();
+  const reorder = useReorderTargets();
+  const [localOrder, setLocalOrder] = useState<string[] | null>(null);
+
+  const orderedTargets = useMemo(() => {
+    const data = [...targets].sort((a, b) => a.priority - b.priority);
+    if (localOrder) {
+      const map = new Map(data.map((item) => [item.id, item] as const));
+      return localOrder
+        .map((id) => map.get(id))
+        .filter((value): value is typeof data[number] => Boolean(value))
+        .concat(data.filter((item) => !localOrder.includes(item.id)));
+    }
+    return data;
+  }, [targets, localOrder]);
+
+  const applyOrder = () => {
+    const ids = (localOrder ?? orderedTargets.map((item) => item.id));
+    reorder.mutate(ids, {
+      onSuccess: () => {
+        setLocalOrder(null);
+      }
+    });
+  };
+
+  const moveItem = (id: string, direction: -1 | 1) => {
+    setLocalOrder((prev) => {
+      const source = prev ?? orderedTargets.map((item) => item.id);
+      const index = source.indexOf(id);
+      if (index < 0) {
+        return source;
+      }
+      const targetIndex = index + direction;
+      if (targetIndex < 0 || targetIndex >= source.length) {
+        return source;
+      }
+      const next = [...source];
+      const [removed] = next.splice(index, 1);
+      next.splice(targetIndex, 0, removed);
+      return next;
+    });
+  };
+
+  const resetOrder = () => setLocalOrder(null);
+
+  return (
+    <div className="space-y-6">
+      <AdminSectionCard
+        title="운영 현황 요약"
+        description="현재 인덱싱된 계정 및 게시물 수치를 확인합니다."
+      >
+        {statistics ? (
+          <dl className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+              <dt className="text-xs uppercase tracking-wide text-slate-400">전체 계정</dt>
+              <dd className="mt-2 text-2xl font-semibold text-brand-200">
+                {statistics.totalTargets.toLocaleString()}
+              </dd>
+            </div>
+            <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+              <dt className="text-xs uppercase tracking-wide text-slate-400">활성 계정</dt>
+              <dd className="mt-2 text-2xl font-semibold text-brand-200">
+                {statistics.activeTargets.toLocaleString()}
+              </dd>
+            </div>
+            <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+              <dt className="text-xs uppercase tracking-wide text-slate-400">피쳐드 계정</dt>
+              <dd className="mt-2 text-2xl font-semibold text-brand-200">
+                {statistics.featuredTargets.toLocaleString()}
+              </dd>
+            </div>
+            <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+              <dt className="text-xs uppercase tracking-wide text-slate-400">총 게시물 수</dt>
+              <dd className="mt-2 text-2xl font-semibold text-brand-200">
+                {statistics.totalPosts.toLocaleString()}
+              </dd>
+              <p className="mt-1 text-xs text-slate-400">
+                마지막 동기화: {statistics.lastIndexedAt ? new Date(statistics.lastIndexedAt).toLocaleString() : '기록 없음'}
+              </p>
+            </div>
+          </dl>
+        ) : (
+          <p className="text-sm text-slate-400">통계 데이터를 불러오는 중입니다…</p>
+        )}
+      </AdminSectionCard>
+
+      <AdminSectionCard
+        title="피드 노출 순서"
+        description="드래그 대신 순서 버튼으로 정렬한 뒤 저장합니다."
+        actions={
+          <div className="flex items-center gap-2 text-xs">
+            <button
+              type="button"
+              onClick={resetOrder}
+              className="rounded border border-slate-700 px-3 py-1 transition hover:border-slate-500"
+              disabled={!localOrder}
+            >
+              되돌리기
+            </button>
+            <button
+              type="button"
+              onClick={applyOrder}
+              className="rounded bg-brand-500/80 px-3 py-1 font-semibold text-slate-950 transition hover:bg-brand-400"
+              disabled={reorder.isPending}
+            >
+              순서 저장
+            </button>
+          </div>
+        }
+      >
+        <ul className="space-y-2">
+          {orderedTargets.map((target, index) => (
+            <li
+              key={target.id}
+              className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-900/80 px-4 py-3"
+            >
+              <div>
+                <p className="text-sm font-semibold text-slate-100">
+                  #{index + 1} — {target.displayName}
+                </p>
+                <p className="text-xs text-slate-400">@{target.handle}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => moveItem(target.id, -1)}
+                  className="rounded border border-slate-700 px-2 py-1 text-xs hover:border-slate-500"
+                >
+                  위로
+                </button>
+                <button
+                  type="button"
+                  onClick={() => moveItem(target.id, 1)}
+                  className="rounded border border-slate-700 px-2 py-1 text-xs hover:border-slate-500"
+                >
+                  아래로
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </AdminSectionCard>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/frontend/src/routes/admin/AdminGate.tsx
+++ b/frontend/src/routes/admin/AdminGate.tsx
@@ -1,0 +1,43 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import AdminLayout from '../../components/admin/AdminLayout';
+import { useAuth } from '../../lib/auth/context';
+import { useAuthGuard } from '../../lib/auth/useAuthGuard';
+
+const AdminGate = () => {
+  const auth = useAuth();
+  const guard = useAuthGuard();
+
+  if (auth.isLoading || guard.isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-200">
+        <div className="space-y-3 text-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-2 border-brand-400 border-t-transparent" />
+          <p className="text-sm">Authentik 인증 정보를 확인 중입니다…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!guard.isAuthenticated || !guard.hasAdminRole) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-300">
+        <div className="space-y-2 text-center">
+          <p className="text-lg font-semibold">관리자 인증이 필요합니다.</p>
+          <p className="text-sm text-slate-400">Authentik 로그인 화면으로 이동합니다…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!auth.hasAdminRole) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <AdminLayout>
+      <Outlet />
+    </AdminLayout>
+  );
+};
+
+export default AdminGate;

--- a/frontend/src/routes/admin/AdminRunsPage.tsx
+++ b/frontend/src/routes/admin/AdminRunsPage.tsx
@@ -1,0 +1,133 @@
+import { FormEvent, useState } from 'react';
+import AdminSectionCard from '../../components/admin/AdminSectionCard';
+import { useCrawlTargets } from '../../hooks/admin/useCrawlTargets';
+import { useCrawlRuns, useTriggerRun } from '../../hooks/admin/useCrawlRuns';
+
+const AdminRunsPage = () => {
+  const { targets } = useCrawlTargets();
+  const { runs, isPending } = useCrawlRuns();
+  const triggerRun = useTriggerRun();
+  const [selectedTargetId, setSelectedTargetId] = useState<string>('');
+  const [sessionId, setSessionId] = useState('');
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!selectedTargetId || !sessionId.trim()) {
+      return;
+    }
+
+    triggerRun.mutate(
+      {
+        targetId: selectedTargetId,
+        sessionId
+      },
+      {
+        onSuccess: () => setSessionId('')
+      }
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <AdminSectionCard
+        title="수동 크롤링 실행"
+        description="세션 ID를 지정하여 즉시 크롤링을 트리거합니다."
+      >
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3 md:flex-row md:items-end">
+          <label className="flex flex-1 flex-col gap-2 text-sm">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+              대상 계정
+            </span>
+            <select
+              className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 focus:border-brand-400 focus:outline-none"
+              value={selectedTargetId}
+              onChange={(event) => setSelectedTargetId(event.target.value)}
+            >
+              <option value="">대상을 선택하세요</option>
+              {targets.map((target) => (
+                <option key={target.id} value={target.id}>
+                  #{target.priority} — {target.displayName} (@{target.handle})
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-1 flex-col gap-2 text-sm">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+              sessionId
+            </span>
+            <input
+              className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 focus:border-brand-400 focus:outline-none"
+              value={sessionId}
+              onChange={(event) => setSessionId(event.target.value)}
+              placeholder="sessionid=..."
+            />
+          </label>
+          <button
+            type="submit"
+            className="rounded bg-brand-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-brand-400"
+            disabled={triggerRun.isPending}
+          >
+            실행 요청
+          </button>
+        </form>
+      </AdminSectionCard>
+
+      <AdminSectionCard
+        title="실행 이력"
+        description="최근 수동/자동 실행 로그를 확인하여 상태를 파악합니다."
+      >
+        {isPending ? (
+          <p className="text-sm text-slate-400">실행 이력을 불러오는 중입니다…</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-800 text-sm">
+              <thead className="bg-slate-900/50 text-xs uppercase tracking-wide text-slate-400">
+                <tr>
+                  <th className="px-4 py-2 text-left">대상</th>
+                  <th className="px-4 py-2 text-left">세션</th>
+                  <th className="px-4 py-2 text-left">상태</th>
+                  <th className="px-4 py-2 text-left">시작</th>
+                  <th className="px-4 py-2 text-left">종료</th>
+                  <th className="px-4 py-2 text-left">메시지</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-800">
+                {runs.map((run) => (
+                  <tr key={run.id} className="hover:bg-slate-900/70">
+                    <td className="px-4 py-3 text-slate-100">@{run.targetHandle}</td>
+                    <td className="px-4 py-3 font-mono text-xs text-slate-300">{run.sessionId}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={[
+                          'rounded-full px-3 py-1 text-xs font-semibold',
+                          run.status === 'success'
+                            ? 'bg-emerald-500/20 text-emerald-200'
+                            : run.status === 'failure'
+                              ? 'bg-red-500/20 text-red-200'
+                              : run.status === 'running'
+                                ? 'bg-sky-500/20 text-sky-200'
+                                : 'bg-slate-600/30 text-slate-200'
+                        ].join(' ')}
+                      >
+                        {run.status.toUpperCase()}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">
+                      {new Date(run.startedAt).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">
+                      {run.finishedAt ? new Date(run.finishedAt).toLocaleString() : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">{run.message ?? '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </AdminSectionCard>
+    </div>
+  );
+};
+
+export default AdminRunsPage;

--- a/frontend/src/routes/admin/AdminTargetsPage.tsx
+++ b/frontend/src/routes/admin/AdminTargetsPage.tsx
@@ -1,0 +1,248 @@
+import { FormEvent, useMemo, useState } from 'react';
+import AdminSectionCard from '../../components/admin/AdminSectionCard';
+import {
+  useCreateTarget,
+  useCrawlTargets,
+  useDeleteTarget,
+  useUpdateTarget
+} from '../../hooks/admin/useCrawlTargets';
+
+interface FormState {
+  handle: string;
+  displayName: string;
+  isFeatured: boolean;
+  isActive: boolean;
+}
+
+const initialFormState: FormState = {
+  handle: '',
+  displayName: '',
+  isFeatured: false,
+  isActive: true
+};
+
+const AdminTargetsPage = () => {
+  const { targets, isPending } = useCrawlTargets();
+  const createTarget = useCreateTarget();
+  const updateTarget = useUpdateTarget();
+  const deleteTarget = useDeleteTarget();
+  const [form, setForm] = useState<FormState>(initialFormState);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const sortedTargets = useMemo(
+    () => [...targets].sort((a, b) => a.priority - b.priority),
+    [targets]
+  );
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!form.handle.trim()) {
+      return;
+    }
+
+    if (editingId) {
+      updateTarget.mutate({
+        id: editingId,
+        patch: {
+          displayName: form.displayName,
+          isFeatured: form.isFeatured,
+          isActive: form.isActive
+        }
+      }, {
+        onSuccess: () => {
+          setEditingId(null);
+          setForm(initialFormState);
+        }
+      });
+      return;
+    }
+
+    createTarget.mutate(
+      {
+        handle: form.handle,
+        displayName: form.displayName,
+        isFeatured: form.isFeatured,
+        isActive: form.isActive
+      },
+      {
+        onSuccess: () => setForm(initialFormState)
+      }
+    );
+  };
+
+  const startEdit = (id: string) => {
+    const target = targets.find((item) => item.id === id);
+    if (!target) {
+      return;
+    }
+
+    setEditingId(id);
+    setForm({
+      handle: target.handle,
+      displayName: target.displayName,
+      isFeatured: target.isFeatured,
+      isActive: target.isActive
+    });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setForm(initialFormState);
+  };
+
+  return (
+    <div className="space-y-6">
+      <AdminSectionCard
+        title="크롤링 대상 추가"
+        description="Instagram ID를 등록하여 주기적인 인덱싱을 수행합니다."
+      >
+        <form onSubmit={handleSubmit} className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+              Instagram Handle
+            </span>
+            <input
+              className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 focus:border-brand-400 focus:outline-none"
+              value={form.handle}
+              onChange={(event) => setForm((prev) => ({ ...prev, handle: event.target.value }))}
+              placeholder="fromis_9"
+              disabled={Boolean(editingId)}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+              표시 이름
+            </span>
+            <input
+              className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 focus:border-brand-400 focus:outline-none"
+              value={form.displayName}
+              onChange={(event) => setForm((prev) => ({ ...prev, displayName: event.target.value }))}
+              placeholder="fromis_9 공식"
+            />
+          </label>
+          <label className="flex items-center gap-3 text-sm">
+            <input
+              type="checkbox"
+              className="size-4 rounded border border-slate-600 bg-slate-950 accent-brand-400"
+              checked={form.isFeatured}
+              onChange={(event) => setForm((prev) => ({ ...prev, isFeatured: event.target.checked }))}
+            />
+            <span>피드 상단에 노출</span>
+          </label>
+          <label className="flex items-center gap-3 text-sm">
+            <input
+              type="checkbox"
+              className="size-4 rounded border border-slate-600 bg-slate-950 accent-brand-400"
+              checked={form.isActive}
+              onChange={(event) => setForm((prev) => ({ ...prev, isActive: event.target.checked }))}
+            />
+            <span>크롤링 활성화</span>
+          </label>
+          <div className="col-span-full flex items-center gap-2">
+            <button
+              type="submit"
+              className="rounded bg-brand-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-brand-400"
+              disabled={createTarget.isPending || updateTarget.isPending}
+            >
+              {editingId ? '대상 수정' : '대상 추가'}
+            </button>
+            {editingId ? (
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="rounded border border-slate-700 px-4 py-2 text-sm hover:border-slate-500"
+              >
+                취소
+              </button>
+            ) : null}
+          </div>
+        </form>
+      </AdminSectionCard>
+
+      <AdminSectionCard
+        title="등록된 크롤링 대상"
+        description="활성 여부 및 피쳐드 토글을 조정해 노출 대상을 관리합니다."
+      >
+        {isPending ? (
+          <p className="text-sm text-slate-400">대상 목록을 불러오는 중입니다…</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-800 text-sm">
+              <thead className="bg-slate-900/50 text-xs uppercase tracking-wide text-slate-400">
+                <tr>
+                  <th className="px-4 py-2 text-left">우선순위</th>
+                  <th className="px-4 py-2 text-left">Handle</th>
+                  <th className="px-4 py-2 text-left">표시 이름</th>
+                  <th className="px-4 py-2 text-center">피쳐드</th>
+                  <th className="px-4 py-2 text-center">활성</th>
+                  <th className="px-4 py-2 text-left">최근 동기화</th>
+                  <th className="px-4 py-2 text-left">게시물 수</th>
+                  <th className="px-4 py-2 text-right">관리</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-800">
+                {sortedTargets.map((target) => (
+                  <tr key={target.id} className="hover:bg-slate-900/70">
+                    <td className="px-4 py-3 text-xs text-slate-400">#{target.priority}</td>
+                    <td className="px-4 py-3 font-mono text-slate-100">@{target.handle}</td>
+                    <td className="px-4 py-3 text-slate-100">{target.displayName}</td>
+                    <td className="px-4 py-3 text-center">
+                      <input
+                        type="checkbox"
+                        className="size-4 rounded border border-slate-600 bg-slate-950 accent-brand-400"
+                        checked={target.isFeatured}
+                        onChange={(event) =>
+                          updateTarget.mutate({
+                            id: target.id,
+                            patch: { isFeatured: event.target.checked }
+                          })
+                        }
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <input
+                        type="checkbox"
+                        className="size-4 rounded border border-slate-600 bg-slate-950 accent-brand-400"
+                        checked={target.isActive}
+                        onChange={(event) =>
+                          updateTarget.mutate({
+                            id: target.id,
+                            patch: { isActive: event.target.checked }
+                          })
+                        }
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-slate-300">
+                      {target.lastSyncedAt ? new Date(target.lastSyncedAt).toLocaleString() : '기록 없음'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-100">{target.postCount.toLocaleString()}</td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => startEdit(target.id)}
+                          className="rounded border border-slate-700 px-3 py-1 text-xs hover:border-slate-500"
+                        >
+                          수정
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => deleteTarget.mutate(target.id)}
+                          className="rounded border border-red-600/60 px-3 py-1 text-xs text-red-300 hover:border-red-500"
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </AdminSectionCard>
+    </div>
+  );
+};
+
+export default AdminTargetsPage;

--- a/plans/plan5.md
+++ b/plans/plan5.md
@@ -5,12 +5,12 @@ Plan 5 — 어드민 패널 & Authentik 연동
 - `/admin` 경로의 SPA를 구축하고 Authentik OIDC 인증을 연동하여 크롤링/노출 관리 기능을 제공한다.
 
 ## 상세 작업 항목 체크리스트
-- [ ] Authentik OIDC 클라이언트 설정 및 토큰 검증 로직 구현
-- [ ] 어드민 전용 라우터/레이아웃 및 역할 기반 가드 적용
-- [ ] 크롤링 대상(ID) CRUD 및 `is_active`/`is_featured` 토글 UI 구성
-- [ ] 크롤링 로그인 계정 CRUD + 세션 입력 폼 구현
-- [ ] 수동 크롤링 실행 트리거 및 실행 이력 테이블 작성
-- [ ] 피드 노출 순서/통계 대시보드 구성
+- [x] Authentik OIDC 클라이언트 설정 및 토큰 검증 로직 구현
+- [x] 어드민 전용 라우터/레이아웃 및 역할 기반 가드 적용
+- [x] 크롤링 대상(ID) CRUD 및 `is_active`/`is_featured` 토글 UI 구성
+- [x] 크롤링 로그인 계정 CRUD + 세션 입력 폼 구현
+- [x] 수동 크롤링 실행 트리거 및 실행 이력 테이블 작성
+- [x] 피드 노출 순서/통계 대시보드 구성
 
 ## 예상 산출물
 - 어드민 SPA 페이지와 컴포넌트
@@ -18,7 +18,7 @@ Plan 5 — 어드민 패널 & Authentik 연동
 - 어드민 API 통신 훅/서비스
 
 ## 완료 여부
-status: pending
+status: done
 
 ## 필요 기술/참고 문서
 - Authentik OIDC 문서


### PR DESCRIPTION
## Summary
- add Authentik-aware auth provider and guard to protect the new /admin SPA routes
- implement admin dashboard pages for crawl targets, login accounts, runs, and feed ordering backed by mock admin API hooks
- document Authentik configuration and provide environment variable template while marking plan5 as complete

## Testing
- pnpm --filter @fromistargram/frontend lint

------
https://chatgpt.com/codex/tasks/task_e_690cb8530578832681c637ab6ab37da0