### PR TITLE
Fix Prisma client import for ESM runtime

### DIFF
--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,11 +1,15 @@
-import { PrismaClient } from '@prisma/client';
+import prismaPkg from '@prisma/client';
+
+const { PrismaClient } = prismaPkg as typeof import('@prisma/client');
 
 export const prisma = new PrismaClient({
   log: process.env.NODE_ENV === 'production' ? ['error'] : ['query', 'error', 'warn']
 });
 
-export type PrismaTransaction = Parameters<PrismaClient['$transaction']>[0];
+type PrismaClientInstance = InstanceType<typeof PrismaClient>;
 
-export async function withPrisma<T>(handler: (client: PrismaClient) => Promise<T>): Promise<T> {
+export type PrismaTransaction = Parameters<PrismaClientInstance['$transaction']>[0];
+
+export async function withPrisma<T>(handler: (client: PrismaClientInstance) => Promise<T>): Promise<T> {
   return handler(prisma);
 }


### PR DESCRIPTION
## Summary
- adjust the Prisma client bootstrap to import from the CommonJS package via the default export
- update helper types to derive from the instantiated Prisma client for correct typing

## Testing
- pnpm --filter @fromistargram/backend build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d5da51e00832698db5b1b9a407854)