### PR TITLE
Add error logging for admin actions

### DIFF
--- a/backend/src/routes/registerAdminMetricsRoutes.ts
+++ b/backend/src/routes/registerAdminMetricsRoutes.ts
@@ -32,9 +32,14 @@ export async function registerAdminMetricsRoutes(app: FastifyInstance): Promise<
         }
       }
     },
-    async () => {
-      const data = await fetchFeedStatistics();
-      return { data };
+    async (request, reply) => {
+      try {
+        const data = await fetchFeedStatistics();
+        return { data };
+      } catch (error) {
+        request.log.error(error, 'Failed to fetch feed statistics');
+        return reply.code(500).send({ message: 'Failed to fetch feed statistics' });
+      }
     }
   );
 }


### PR DESCRIPTION
## Summary
- add error logging when launching the crawler process to capture spawn and runtime failures
- add consistent admin endpoint error logging and improved error responses for invalid requests

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f09eb85908326a6ea28fe859ee6ae)