### PR TITLE
Handle manual runs using active target handles

### DIFF
--- a/backend/src/routes/registerAdminRunRoutes.ts
+++ b/backend/src/routes/registerAdminRunRoutes.ts
@@ -41,8 +41,8 @@ const singleResponseSchema = {
 } as const;
 
 const triggerBodySchema = z.object({
-  targetId: z.string().min(1),
-  sessionId: z.string().min(1)
+  sessionId: z.string().min(1),
+  targetId: z.string().min(1).optional()
 });
 
 const triggerBodyJsonSchema = {
@@ -51,7 +51,7 @@ const triggerBodyJsonSchema = {
     targetId: { type: 'string', minLength: 1 },
     sessionId: { type: 'string', minLength: 1 }
   },
-  required: ['targetId', 'sessionId'],
+  required: ['sessionId'],
   additionalProperties: false
 } as const;
 

--- a/frontend/src/lib/api/admin/mockData.ts
+++ b/frontend/src/lib/api/admin/mockData.ts
@@ -256,7 +256,10 @@ export const createMockAdminApiClient = (): AdminApiClient => ({
     return delay([...runs]);
   },
   async triggerRun(payload: ManualRunPayload) {
-    const target = targets.find((item) => item.id === payload.targetId);
+    const target = payload.targetId
+      ? targets.find((item) => item.id === payload.targetId)
+      : targets.find((item) => item.isActive) ?? targets[0];
+
     if (!target) {
       throw new Error('Target not found');
     }

--- a/frontend/src/lib/api/admin/types.ts
+++ b/frontend/src/lib/api/admin/types.ts
@@ -64,7 +64,7 @@ export interface CrawlRun {
 }
 
 export interface ManualRunPayload {
-  targetId: string;
+  targetId?: string;
   sessionId: string;
 }
 

--- a/frontend/src/routes/admin/AdminRunsPage.tsx
+++ b/frontend/src/routes/admin/AdminRunsPage.tsx
@@ -68,19 +68,15 @@ const AdminRunsPage = () => {
   const handleBulkSubmit = (event: FormEvent) => {
     event.preventDefault();
     setBulkMessage(null);
-    const activeTargets = targets.filter((target) => target.isActive);
-    if (!activeTargets.length || !bulkSessionId.trim()) {
+    const activeCount = targets.filter((target) => target.isActive).length;
+    if (!activeCount || !bulkSessionId.trim()) {
       setBulkMessage('활성화된 대상이 없거나 sessionId가 비어 있습니다.');
       return;
     }
 
-    activeTargets.forEach((target, index) => {
-      setTimeout(() => {
-        runMutate({ targetId: target.id, sessionId: bulkSessionId });
-      }, index * 100);
-    });
+    runMutate({ sessionId: bulkSessionId });
 
-    setBulkMessage(`활성 대상 ${activeTargets.length}개를 순차 실행 중입니다.`);
+    setBulkMessage(`활성 대상 ${activeCount}개 실행을 요청했습니다.`);
     setBulkSessionId('');
   };
 


### PR DESCRIPTION
## Summary
- allow manual run requests to omit target ids and rely on active targets fetched server-side
- pass resolved handle lists to the crawler process when triggering manual runs
- adjust admin bulk run submission to send a single request with just the session id

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692419dac5e88326901d903c40856ed1)