### PR TITLE
Add filename-based media streaming endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,3 +31,5 @@ pnpm --filter @fromistargram/backend lint   # 타입 검사
 ## 썸네일 서버 연동
 
 `/api/media/:account/:filename` 엔드포인트는 `MEDIA_ROOT` 환경 변수 기반으로 원본 파일을 Range 스트리밍합니다. 추후 `imgproxy` 와 같은 썸네일 서버를 붙일 때는 해당 경로를 역프록시 대상으로 활용하거나, Fastify 플러그인으로 프리사이즈 이미지를 반환하도록 확장할 수 있습니다.
+
+크롤링 산출물 이름(예: `2025-02-18_10-59-28_UTC_profile_pic.jpg`)만 전달되는 경우에는 `/api/media/by-filename/:filename` 를 사용하세요. 백엔드는 DB에서 해당 파일을 보유한 계정을 조회한 뒤 `/root/<account>/<filename>` 경로의 실제 파일을 Range 스트리밍합니다. 중복 파일명이 둘 이상 발견되면 409를 반환해 모호성을 알립니다.

--- a/backend/src/routes/registerMediaRoutes.ts
+++ b/backend/src/routes/registerMediaRoutes.ts
@@ -5,11 +5,49 @@ import { FastifyInstance } from 'fastify';
 import { lookup } from 'mime-types';
 import { z } from 'zod';
 import { sendFileWithRange } from '../utils/range.js';
+import { prisma } from '../db/client.js';
 
 const paramsSchema = z.object({
   account: z.string().min(1),
   filename: z.string().min(1)
 });
+
+const filenameOnlySchema = z.object({
+  filename: z.string().min(1).refine((value) => !value.includes('/') && !value.includes('..'), {
+    message: 'Invalid filename'
+  })
+});
+
+async function resolveAccountForFilename(filename: string): Promise<{ accountId: string } | { ambiguous: true } | null> {
+  const [mediaMatches, profilePicMatches] = await Promise.all([
+    prisma.media.findMany({
+      where: { filename },
+      select: { post: { select: { accountId: true } } },
+      take: 2
+    }),
+    prisma.profilePic.findMany({
+      where: { filename },
+      select: { accountId: true },
+      take: 2
+    })
+  ]);
+
+  const accountIds = [
+    ...mediaMatches.map((match) => match.post.accountId),
+    ...profilePicMatches.map((match) => match.accountId)
+  ];
+
+  if (accountIds.length === 0) {
+    return null;
+  }
+
+  const uniqueAccounts = new Set(accountIds);
+  if (uniqueAccounts.size > 1 || accountIds.length > 1) {
+    return { ambiguous: true } as const;
+  }
+
+  return { accountId: accountIds[0] };
+}
 
 export async function registerMediaRoutes(app: FastifyInstance): Promise<void> {
   const dataRoot = process.env.MEDIA_ROOT ?? '/root';
@@ -48,6 +86,76 @@ export async function registerMediaRoutes(app: FastifyInstance): Promise<void> {
     async (request, reply) => {
       const { account, filename } = paramsSchema.parse(request.params);
       const filePath = path.join(dataRoot, account, filename);
+
+      try {
+        await access(filePath, constants.R_OK);
+      } catch (error) {
+        app.log.warn(error, 'Media not found: %s', filePath);
+        return reply.code(404).send({ message: 'Media not found' });
+      }
+
+      const mimeType = lookup(filename) || 'application/octet-stream';
+      return sendFileWithRange(reply, {
+        filePath,
+        rangeHeader: request.headers.range,
+        mimeType
+      });
+    }
+  );
+
+  app.get(
+    '/api/media/by-filename/:filename',
+    {
+      schema: {
+        tags: ['Media'],
+        summary: 'Stream media or profile picture by filename only',
+        params: {
+          type: 'object',
+          properties: {
+            filename: { type: 'string' }
+          },
+          required: ['filename'],
+          additionalProperties: false
+        },
+        response: {
+          200: {
+            type: 'string',
+            format: 'binary'
+          },
+          404: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' }
+            },
+            required: ['message'],
+            additionalProperties: false
+          },
+          409: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' }
+            },
+            required: ['message'],
+            additionalProperties: false
+          }
+        }
+      }
+    },
+    async (request, reply) => {
+      const { filename } = filenameOnlySchema.parse(request.params);
+
+      const resolution = await resolveAccountForFilename(filename);
+      if (!resolution) {
+        return reply.code(404).send({ message: 'Media not found' });
+      }
+
+      if ('ambiguous' in resolution) {
+        return reply
+          .code(409)
+          .send({ message: 'Multiple media records share this filename' });
+      }
+
+      const filePath = path.join(dataRoot, resolution.accountId, filename);
 
       try {
         await access(filePath, constants.R_OK);


### PR DESCRIPTION
## Summary
- add a filename-only media endpoint that resolves the owning account before streaming
- guard against ambiguous filename matches and propagate helpful status codes
- document the new endpoint and resolution behavior in the backend README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692442ec57888326b7f9c678c2fd53d8)