### PR TITLE
Fix Prisma typings for admin database overview

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -7,6 +7,7 @@ import { registerAdminTargetRoutes } from './registerAdminTargetRoutes.js';
 import { registerAdminRunRoutes } from './registerAdminRunRoutes.js';
 import { registerAdminMetricsRoutes } from './registerAdminMetricsRoutes.js';
 import { registerAdminIndexerRoutes } from './registerAdminIndexerRoutes.js';
+import { registerAdminDatabaseRoutes } from './registerAdminDatabaseRoutes.js';
 import { registerHighlightRoutes } from './highlights.js';
 import { registerImageProxyRoutes } from './imageProxy.js';
 
@@ -19,6 +20,7 @@ export async function registerApiRoutes(app: FastifyInstance): Promise<void> {
   await app.register(registerAdminRunRoutes);
   await app.register(registerAdminMetricsRoutes);
   await app.register(registerAdminIndexerRoutes);
+  await app.register(registerAdminDatabaseRoutes);
   await app.register(registerHighlightRoutes);
   await app.register(registerImageProxyRoutes);
 

--- a/backend/src/routes/registerAdminDatabaseRoutes.ts
+++ b/backend/src/routes/registerAdminDatabaseRoutes.ts
@@ -1,0 +1,62 @@
+import { FastifyInstance } from 'fastify';
+import { fetchDatabaseOverview } from '../services/databaseInspectService.js';
+
+const tablePreviewSchema = {
+  type: 'object',
+  properties: {
+    key: { type: 'string' },
+    label: { type: 'string' },
+    count: { type: 'integer' },
+    latestRows: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: true
+      }
+    }
+  },
+  required: ['key', 'label', 'count', 'latestRows'],
+  additionalProperties: false
+} as const;
+
+const databaseOverviewSchema = {
+  type: 'object',
+  properties: {
+    tables: {
+      type: 'array',
+      items: tablePreviewSchema
+    }
+  },
+  required: ['tables'],
+  additionalProperties: false
+} as const;
+
+export async function registerAdminDatabaseRoutes(app: FastifyInstance): Promise<void> {
+  app.get(
+    '/api/admin/db-overview',
+    {
+      schema: {
+        tags: ['AdminDatabase'],
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              data: databaseOverviewSchema
+            },
+            required: ['data'],
+            additionalProperties: false
+          }
+        }
+      }
+    },
+    async (request, reply) => {
+      try {
+        const data = await fetchDatabaseOverview();
+        return { data };
+      } catch (error) {
+        request.log.error(error, 'Failed to fetch database overview');
+        return reply.code(500).send({ message: 'Failed to load database overview' });
+      }
+    }
+  );
+}

--- a/backend/src/services/databaseInspectService.ts
+++ b/backend/src/services/databaseInspectService.ts
@@ -1,0 +1,136 @@
+import { withPrisma } from '../db/client.js';
+
+export interface TablePreview {
+  key: string;
+  label: string;
+  count: number;
+  latestRows: Record<string, unknown>[];
+}
+
+export interface DatabaseOverview {
+  tables: TablePreview[];
+}
+
+export async function fetchDatabaseOverview(): Promise<DatabaseOverview> {
+  return withPrisma(async (client) => {
+    const [
+      accounts,
+      accountCount,
+      posts,
+      postCount,
+      crawlTargets,
+      targetCount,
+      crawlRuns,
+      runCount,
+      crawlAccounts,
+      crawlAccountCount,
+      tags,
+      tagCount,
+      highlights,
+      highlightCount
+    ] = await Promise.all([
+      client.account.findMany({
+        orderBy: { updatedAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          lastIndexedAt: true,
+          createdAt: true,
+          updatedAt: true,
+          _count: { select: { posts: true, highlights: true } }
+        }
+      }),
+      client.account.count(),
+      client.post.findMany({
+        orderBy: { postedAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          accountId: true,
+          postedAt: true,
+          type: true,
+          hasText: true,
+          createdAt: true,
+          updatedAt: true,
+          _count: { select: { media: true, tags: true } }
+        }
+      }),
+      client.post.count(),
+      client.crawlTarget.findMany({
+        orderBy: { updatedAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          handle: true,
+          displayName: true,
+          isActive: true,
+          isFeatured: true,
+          priority: true,
+          lastSyncedAt: true,
+          createdAt: true,
+          updatedAt: true
+        }
+      }),
+      client.crawlTarget.count(),
+      client.crawlRun.findMany({
+        orderBy: { startedAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          targetId: true,
+          status: true,
+          sessionId: true,
+          triggeredBy: true,
+          startedAt: true,
+          finishedAt: true,
+          message: true
+        }
+      }),
+      client.crawlRun.count(),
+      client.crawlAccount.findMany({
+        orderBy: { updatedAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          username: true,
+          status: true,
+          lastSessionAt: true,
+          createdAt: true,
+          updatedAt: true,
+          note: true
+        }
+      }),
+      client.crawlAccount.count(),
+      client.tag.findMany({
+        orderBy: { id: 'desc' },
+        take: 5,
+        select: { id: true, name: true }
+      }),
+      client.tag.count(),
+      client.highlight.findMany({
+        orderBy: { updatedAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          accountId: true,
+          title: true,
+          createdAt: true,
+          updatedAt: true
+        }
+      }),
+      client.highlight.count()
+    ]);
+
+    const tables: TablePreview[] = [
+      { key: 'accounts', label: '계정', count: accountCount, latestRows: accounts },
+      { key: 'posts', label: '게시물', count: postCount, latestRows: posts },
+      { key: 'crawlTargets', label: '크롤링 대상', count: targetCount, latestRows: crawlTargets },
+      { key: 'crawlRuns', label: '크롤 실행', count: runCount, latestRows: crawlRuns },
+      { key: 'crawlAccounts', label: '크롤 계정', count: crawlAccountCount, latestRows: crawlAccounts },
+      { key: 'tags', label: '태그', count: tagCount, latestRows: tags },
+      { key: 'highlights', label: '하이라이트', count: highlightCount, latestRows: highlights }
+    ];
+
+    return { tables };
+  });
+}

--- a/backend/src/types/prisma.d.ts
+++ b/backend/src/types/prisma.d.ts
@@ -146,6 +146,7 @@ declare module '@prisma/client' {
       create(...args: any[]): Promise<CrawlAccount>;
       update(...args: any[]): Promise<CrawlAccount>;
       delete(...args: any[]): Promise<CrawlAccount>;
+      count(...args: any[]): Promise<number>;
     };
     crawlTarget: {
       findMany(...args: any[]): Promise<CrawlTarget[]>;
@@ -155,11 +156,13 @@ declare module '@prisma/client' {
       delete(...args: any[]): Promise<CrawlTarget>;
       aggregate(...args: any[]): Promise<any>;
       groupBy(...args: any[]): Promise<any[]>;
+      count(...args: any[]): Promise<number>;
     };
     crawlRun: {
       findMany(...args: any[]): Promise<CrawlRun[]>;
       create(...args: any[]): Promise<CrawlRun>;
       update(...args: any[]): Promise<CrawlRun>;
+      count(...args: any[]): Promise<number>;
     };
     post: {
       findMany(...args: any[]): Promise<Post[]>;
@@ -180,7 +183,9 @@ declare module '@prisma/client' {
       findMany(...args: any[]): Promise<ProfilePic[]>;
     };
     tag: {
+      findMany(...args: any[]): Promise<Tag[]>;
       upsert(...args: any[]): Promise<Tag>;
+      count(...args: any[]): Promise<number>;
     };
     postTag: {
       deleteMany(...args: any[]): Promise<any>;
@@ -194,6 +199,7 @@ declare module '@prisma/client' {
       findUnique(...args: any[]): Promise<Highlight | null>;
       upsert(...args: any[]): Promise<Highlight>;
       update(...args: any[]): Promise<Highlight>;
+      count(...args: any[]): Promise<number>;
     };
     highlightMedia: {
       deleteMany(...args: any[]): Promise<any>;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import AdminGate from './routes/admin/AdminGate';
 import AdminTargetsPage from './routes/admin/AdminTargetsPage';
 import AdminAccountsPage from './routes/admin/AdminAccountsPage';
 import AdminRunsPage from './routes/admin/AdminRunsPage';
+import AdminDatabasePage from './routes/admin/AdminDatabasePage';
 
 const App = () => (
   <AuthProvider>
@@ -17,6 +18,7 @@ const App = () => (
         <Route path="targets" element={<AdminTargetsPage />} />
         <Route path="accounts" element={<AdminAccountsPage />} />
         <Route path="runs" element={<AdminRunsPage />} />
+        <Route path="db" element={<AdminDatabasePage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -12,7 +12,8 @@ const navItems: NavItem[] = [
   { to: '/admin', label: '대시보드', end: true },
   { to: '/admin/targets', label: '크롤링 대상' },
   { to: '/admin/accounts', label: '로그인 계정' },
-  { to: '/admin/runs', label: '실행 이력' }
+  { to: '/admin/runs', label: '실행 이력' },
+  { to: '/admin/db', label: 'DB 내용' }
 ];
 
 interface AdminLayoutProps {

--- a/frontend/src/lib/api/admin/consts.ts
+++ b/frontend/src/lib/api/admin/consts.ts
@@ -5,3 +5,4 @@ export const ADMIN_TARGETS_PATH = '/admin/targets';
 export const ADMIN_RUNS_PATH = '/admin/runs';
 export const ADMIN_FEED_STATISTICS_PATH = '/admin/feed-statistics';
 export const ADMIN_INDEXER_PATH = '/admin/indexer';
+export const ADMIN_DB_OVERVIEW_PATH = '/admin/db-overview';

--- a/frontend/src/lib/api/admin/database.ts
+++ b/frontend/src/lib/api/admin/database.ts
@@ -1,0 +1,6 @@
+import { fetchApi } from '../../queryClient';
+import { ADMIN_DB_OVERVIEW_PATH } from './consts';
+import { type ApiResponse, type DatabaseOverview } from './types';
+
+export const fetchDatabaseOverview = () =>
+  fetchApi.get<ApiResponse<DatabaseOverview>>(ADMIN_DB_OVERVIEW_PATH).then((res) => res.data);

--- a/frontend/src/lib/api/admin/types.ts
+++ b/frontend/src/lib/api/admin/types.ts
@@ -86,6 +86,17 @@ export interface IndexerStatus {
   lastError: string | null;
 }
 
+export interface TablePreview {
+  key: string;
+  label: string;
+  count: number;
+  latestRows: Record<string, unknown>[];
+}
+
+export interface DatabaseOverview {
+  tables: TablePreview[];
+}
+
 export interface AdminApiClient {
   listTargets(): Promise<CrawlTarget[]>;
   createTarget(payload: CrawlTargetPayload): Promise<CrawlTarget>;

--- a/frontend/src/routes/admin/AdminDatabasePage.tsx
+++ b/frontend/src/routes/admin/AdminDatabasePage.tsx
@@ -1,0 +1,117 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import AdminSectionCard from '../../components/admin/AdminSectionCard';
+import { ADMIN_KEY } from '../../lib/api/admin/consts';
+import { fetchDatabaseOverview } from '../../lib/api/admin/database';
+import type { TablePreview } from '../../lib/api/admin/types';
+
+const formatValue = (value: unknown) => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed) && value.includes('T')) {
+      return new Date(parsed).toLocaleString();
+    }
+    return value;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? '예' : '아니오';
+  }
+
+  if (Array.isArray(value)) {
+    return value.length ? JSON.stringify(value) : '[]';
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+};
+
+const TablePreviewCard = ({ table }: { table: TablePreview }) => {
+  const columns = useMemo(() => {
+    const keys = new Set<string>();
+    table.latestRows.forEach((row) => {
+      Object.keys(row).forEach((key) => keys.add(key));
+    });
+    return Array.from(keys);
+  }, [table.latestRows]);
+
+  return (
+    <AdminSectionCard
+      title={`${table.label} (${table.count.toLocaleString()}건)`}
+      description="최근 업데이트된 레코드 5개를 확인합니다."
+    >
+      {table.latestRows.length === 0 ? (
+        <p className="text-sm text-slate-400">아직 저장된 데이터가 없습니다.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-800 text-sm">
+            <thead className="bg-slate-900/60">
+              <tr>
+                {columns.map((column) => (
+                  <th
+                    key={column}
+                    className="px-3 py-2 text-left font-semibold uppercase tracking-wide text-slate-400"
+                  >
+                    {column}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {table.latestRows.map((row) => (
+                <tr key={JSON.stringify(row)} className="hover:bg-slate-900/40">
+                  {columns.map((column) => (
+                    <td key={column} className="px-3 py-2 align-top text-slate-100">
+                      {formatValue((row as Record<string, unknown>)[column])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </AdminSectionCard>
+  );
+};
+
+const AdminDatabasePage = () => {
+  const { data, isPending, isError } = useQuery({
+    queryKey: [ADMIN_KEY, 'database', 'overview'],
+    queryFn: () => fetchDatabaseOverview().then((res) => res.data)
+  });
+
+  if (isPending) {
+    return <p className="text-sm text-slate-400">DB 정보를 불러오는 중입니다…</p>;
+  }
+
+  if (isError || !data) {
+    return <p className="text-sm text-red-300">DB 정보를 불러오지 못했습니다.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <AdminSectionCard
+        title="데이터베이스 미리보기"
+        description="주요 테이블에서 최근 데이터와 전체 건수를 확인합니다."
+      >
+        <p className="text-sm text-slate-300">
+          총 {data.tables.length}개 테이블의 상태를 확인할 수 있습니다.
+        </p>
+      </AdminSectionCard>
+
+      {data.tables.map((table) => (
+        <TablePreviewCard key={table.key} table={table} />
+      ))}
+    </div>
+  );
+};
+
+export default AdminDatabasePage;


### PR DESCRIPTION
## Summary
- add missing Prisma delegate methods to the local type overrides used by admin database overview

## Testing
- npm --prefix backend run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368bf2d25883268422761631135f9f)