### PR TITLE
Allow editing crawl target handles

### DIFF
--- a/backend/src/routes/registerAdminTargetRoutes.ts
+++ b/backend/src/routes/registerAdminTargetRoutes.ts
@@ -74,6 +74,7 @@ const createBodyJsonSchema = {
 
 const updateBodySchema = z
   .object({
+    handle: z.string().min(1).optional(),
     displayName: z.string().min(1).optional(),
     isActive: z.boolean().optional(),
     isFeatured: z.boolean().optional()
@@ -85,6 +86,7 @@ const updateBodySchema = z
 const updateBodyJsonSchema = {
   type: 'object',
   properties: {
+    handle: { type: 'string', minLength: 1 },
     displayName: { type: 'string', minLength: 1 },
     isActive: { type: 'boolean' },
     isFeatured: { type: 'boolean' }

--- a/backend/src/services/crawlTargetsService.ts
+++ b/backend/src/services/crawlTargetsService.ts
@@ -23,6 +23,7 @@ export type CreateCrawlTargetInput = {
 };
 
 export type UpdateCrawlTargetInput = {
+  handle?: string;
   displayName?: string;
   isActive?: boolean;
   isFeatured?: boolean;
@@ -152,9 +153,15 @@ export async function updateCrawlTarget(
     return null;
   }
 
+  const nextHandle = patch.handle?.trim();
+  if (nextHandle && nextHandle !== existing.handle) {
+    await ensureAccountExists(nextHandle);
+  }
+
   const target = (await prisma.crawlTarget.update({
     where: { id },
     data: {
+      handle: nextHandle ?? existing.handle,
       displayName: patch.displayName ?? existing.displayName,
       isActive: patch.isActive ?? existing.isActive,
       isFeatured: patch.isFeatured ?? existing.isFeatured

--- a/frontend/src/lib/api/admin/types.ts
+++ b/frontend/src/lib/api/admin/types.ts
@@ -44,6 +44,7 @@ export interface CrawlTargetPayload {
 }
 
 export interface CrawlTargetPatch {
+  handle?: string;
   displayName?: string;
   isActive?: boolean;
   isFeatured?: boolean;

--- a/frontend/src/routes/admin/AdminTargetsPage.tsx
+++ b/frontend/src/routes/admin/AdminTargetsPage.tsx
@@ -72,6 +72,7 @@ const AdminTargetsPage = () => {
       updateMutate({
         id: editingId,
         patch: {
+          handle: form.handle,
           displayName: form.displayName,
           isFeatured: form.isFeatured,
           isActive: form.isActive


### PR DESCRIPTION
## Summary
- allow admin crawl target updates to include handle changes and ensure accounts exist
- extend admin target validation to accept handle patches
- send updated handles from the admin target form

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69369542225883269e0bc5e3db716e5b)