### PR TITLE
Fix overflow in post modal media

### DIFF
--- a/frontend/src/components/feed/PostModal.tsx
+++ b/frontend/src/components/feed/PostModal.tsx
@@ -194,7 +194,7 @@ const PostModal = ({
           role="dialog"
           aria-modal="true"
           aria-labelledby="post-detail-title"
-          className="flex w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-950 shadow-2xl shadow-black/60 focus:outline-none sm:h-[90vh]"
+          className="flex w-full max-w-5xl flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-950 shadow-2xl shadow-black/60 focus:outline-none sm:h-[90vh] sm:max-h-[95vh]"
           tabIndex={-1}
           onMouseDown={(event) => event.stopPropagation()}
           onClick={(event) => event.stopPropagation()}
@@ -220,7 +220,7 @@ const PostModal = ({
             </button>
           </header>
           <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-5 sm:p-6 lg:flex-row">
-            <div className="flex flex-1 flex-col gap-5">
+            <div className="flex flex-1 min-h-0 flex-col gap-5">
               <PostMediaCarousel
                 media={post?.media ?? []}
                 accountId={post?.accountId ?? ''}

--- a/frontend/src/components/post/PostMediaCarousel.tsx
+++ b/frontend/src/components/post/PostMediaCarousel.tsx
@@ -95,7 +95,7 @@ const PostMediaCarousel = ({
     <div className="flex flex-col gap-3">
       <div
         ref={containerRef}
-        className="relative flex aspect-square w-full items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-black/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+        className="relative flex w-full max-h-[70vh] min-h-[280px] items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-black/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
         tabIndex={0}
         role="group"
         aria-roledescription="carousel"
@@ -118,7 +118,7 @@ const PostMediaCarousel = ({
               key={activeMedia.id}
               {...getResponsiveImageProps(accountId, activeMedia.filename, [600, 1080])}
               alt="게시물 이미지"
-              className="h-full w-full object-contain"
+              className="max-h-full w-full object-contain"
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 80vw, 60vw"
             />
           )

--- a/frontend/src/components/post/VideoPlayer.tsx
+++ b/frontend/src/components/post/VideoPlayer.tsx
@@ -119,7 +119,7 @@ const VideoPlayer = ({ media, className }: VideoPlayerProps) => {
     <div className={`group relative flex h-full w-full items-center justify-center bg-black ${className ?? ''}`}>
       <video
         ref={videoRef}
-        className="h-full w-full object-contain"
+        className="max-h-full w-full object-contain"
         src={media.mediaUrl}
         poster={media.thumbnailUrl}
         preload="metadata"


### PR DESCRIPTION
## Summary
- cap post modal height and allow media area to shrink within available space
- constrain carousel media container height to prevent oversized images and videos
- ensure video and image elements respect container height to avoid scrollbars

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b492f16d883268e4399a4f26138e1)