### PR TITLE
Apply isomorphic 3D styling to admin dashboard

### DIFF
--- a/frontend/src/components/admin/AdminSectionCard.tsx
+++ b/frontend/src/components/admin/AdminSectionCard.tsx
@@ -8,17 +8,17 @@ interface AdminSectionCardProps {
 }
 
 const AdminSectionCard = ({ title, description, actions, children }: AdminSectionCardProps) => (
-  <section className="rounded-xl border border-slate-800 bg-slate-900/60 shadow-lg shadow-slate-900/40">
-    <header className="flex items-start justify-between border-b border-slate-800 px-5 py-4">
+  <section className="relative overflow-hidden rounded-2xl border border-white/60 bg-gradient-to-br from-white/80 via-[#f5f2ff]/70 to-[#e6f7ff]/80 shadow-[0_12px_32px_rgba(126,200,255,0.22),0_4px_14px_rgba(184,164,240,0.2)] backdrop-blur-xl">
+    <header className="flex items-start justify-between border-b border-white/60 bg-gradient-to-r from-[#fdfbff]/70 via-[#f0f7ff]/70 to-[#fdf2ff]/70 px-5 py-4">
       <div>
-        <h2 className="text-base font-semibold text-slate-100">{title}</h2>
+        <h2 className="text-base font-semibold text-slate-700">{title}</h2>
         {description ? (
-          <p className="mt-1 text-sm text-slate-400">{description}</p>
+          <p className="mt-1 text-sm text-slate-600">{description}</p>
         ) : null}
       </div>
       {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
     </header>
-    <div className="px-5 py-4 text-sm text-slate-200">{children}</div>
+    <div className="px-5 py-4 text-sm text-slate-700">{children}</div>
   </section>
 );
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,13 +3,16 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 }
 
 @layer base {
   body {
-    @apply m-0 min-h-screen bg-slate-950 font-sans text-slate-100 antialiased;
-    background: radial-gradient(circle at 20% 20%, #1f2937 0%, #0b1224 45%, #020617 80%);
+    @apply m-0 min-h-screen bg-transparent font-sans text-slate-800 antialiased;
+    background:
+      radial-gradient(120% 120% at 20% 20%, rgba(255, 212, 229, 0.65) 0%, rgba(255, 212, 229, 0.05) 55%),
+      radial-gradient(90% 90% at 85% 10%, rgba(168, 216, 255, 0.7) 0%, rgba(168, 216, 255, 0.08) 50%),
+      linear-gradient(135deg, #ffd4e5 0%, #d4e4ff 30%, #ffe4d4 60%, #e4d4ff 100%);
   }
 
   #root {

--- a/frontend/src/routes/admin/AdminDashboard.tsx
+++ b/frontend/src/routes/admin/AdminDashboard.tsx
@@ -73,36 +73,36 @@ const AdminDashboard = () => {
       >
         {statistics ? (
           <dl className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-            <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-              <dt className="text-xs uppercase tracking-wide text-slate-400">전체 계정</dt>
-              <dd className="mt-2 text-2xl font-semibold text-brand-200">
+            <div className="relative overflow-hidden rounded-2xl border border-white/70 bg-gradient-to-br from-white/90 via-[#eef5ff]/85 to-[#ffeef8]/85 p-4 shadow-[0_10px_28px_rgba(124,180,255,0.22),0_4px_12px_rgba(255,184,212,0.18)] backdrop-blur-lg">
+              <dt className="text-xs uppercase tracking-wide text-slate-600">전체 계정</dt>
+              <dd className="mt-2 text-3xl font-semibold text-[#7ec8ff]">
                 {statistics.totalTargets}
               </dd>
             </div>
-            <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-              <dt className="text-xs uppercase tracking-wide text-slate-400">활성 계정</dt>
-              <dd className="mt-2 text-2xl font-semibold text-brand-200">
+            <div className="relative overflow-hidden rounded-2xl border border-white/70 bg-gradient-to-br from-white/90 via-[#eef5ff]/85 to-[#ffeef8]/85 p-4 shadow-[0_10px_28px_rgba(124,180,255,0.22),0_4px_12px_rgba(255,184,212,0.18)] backdrop-blur-lg">
+              <dt className="text-xs uppercase tracking-wide text-slate-600">활성 계정</dt>
+              <dd className="mt-2 text-3xl font-semibold text-[#8ce8d0]">
                 {statistics.activeTargets}
               </dd>
             </div>
-            <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-              <dt className="text-xs uppercase tracking-wide text-slate-400">피쳐드 계정</dt>
-              <dd className="mt-2 text-2xl font-semibold text-brand-200">
+            <div className="relative overflow-hidden rounded-2xl border border-white/70 bg-gradient-to-br from-white/90 via-[#eef5ff]/85 to-[#ffeef8]/85 p-4 shadow-[0_10px_28px_rgba(124,180,255,0.22),0_4px_12px_rgba(255,184,212,0.18)] backdrop-blur-lg">
+              <dt className="text-xs uppercase tracking-wide text-slate-600">피쳐드 계정</dt>
+              <dd className="mt-2 text-3xl font-semibold text-[#b8a4f0]">
                 {statistics.featuredTargets.toLocaleString()}
               </dd>
             </div>
-            <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-              <dt className="text-xs uppercase tracking-wide text-slate-400">총 게시물 수</dt>
-              <dd className="mt-2 text-2xl font-semibold text-brand-200">
+            <div className="relative overflow-hidden rounded-2xl border border-white/70 bg-gradient-to-br from-white/90 via-[#eef5ff]/85 to-[#ffeef8]/85 p-4 shadow-[0_10px_28px_rgba(124,180,255,0.22),0_4px_12px_rgba(255,184,212,0.18)] backdrop-blur-lg">
+              <dt className="text-xs uppercase tracking-wide text-slate-600">총 게시물 수</dt>
+              <dd className="mt-2 text-3xl font-semibold text-[#ffb8d4]">
                 {statistics.totalPosts.toLocaleString()}
               </dd>
-              <p className="mt-1 text-xs text-slate-400">
+              <p className="mt-1 text-xs text-slate-600">
                 마지막 동기화: {statistics.lastIndexedAt ? new Date(statistics.lastIndexedAt).toLocaleString() : '기록 없음'}
               </p>
             </div>
           </dl>
         ) : (
-          <p className="text-sm text-slate-400">통계 데이터를 불러오는 중입니다…</p>
+          <p className="text-sm text-slate-600">통계 데이터를 불러오는 중입니다…</p>
         )}
       </AdminSectionCard>
 
@@ -114,7 +114,7 @@ const AdminDashboard = () => {
             <button
               type="button"
               onClick={resetOrder}
-              className="rounded border border-slate-700 px-3 py-1 transition hover:border-slate-500"
+              className="rounded-xl border border-white/70 bg-white/60 px-3 py-1 text-slate-600 shadow-[0_6px_16px_rgba(168,216,255,0.22)] transition hover:-translate-y-0.5 hover:shadow-[0_10px_24px_rgba(168,216,255,0.32)] disabled:opacity-60 disabled:shadow-none"
               disabled={!localOrder}
             >
               되돌리기
@@ -122,7 +122,7 @@ const AdminDashboard = () => {
             <button
               type="button"
               onClick={applyOrder}
-              className="rounded bg-brand-500/80 px-3 py-1 font-semibold text-slate-950 transition hover:bg-brand-400"
+              className="rounded-xl bg-[linear-gradient(135deg,#7EC8FF_0%,#B8A4F0_50%,#8CE8D0_100%)] px-3 py-1 font-semibold text-slate-900 shadow-[0_10px_28px_rgba(126,200,255,0.35),0_4px_12px_rgba(140,232,208,0.28)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_32px_rgba(126,200,255,0.45),0_6px_16px_rgba(140,232,208,0.35)] disabled:opacity-60"
               disabled={isPending}
             >
               순서 저장
@@ -134,26 +134,26 @@ const AdminDashboard = () => {
           {orderedTargets.map((target, index) => (
             <li
               key={target.id}
-              className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-900/80 px-4 py-3"
+              className="flex items-center justify-between rounded-2xl border border-white/70 bg-gradient-to-r from-white/90 via-[#f5f0ff]/85 to-[#e8f9f3]/85 px-4 py-3 shadow-[0_10px_26px_rgba(126,200,255,0.2),0_4px_10px_rgba(255,184,212,0.16)] backdrop-blur-lg"
             >
               <div>
-                <p className="text-sm font-semibold text-slate-100">
+                <p className="text-sm font-semibold text-slate-700">
                   #{index + 1} — {target.displayName}
                 </p>
-                <p className="text-xs text-slate-400">@{target.handle}</p>
+                <p className="text-xs text-slate-600">@{target.handle}</p>
               </div>
               <div className="flex items-center gap-2">
                 <button
                   type="button"
                   onClick={() => moveItem(target.id, -1)}
-                  className="rounded border border-slate-700 px-2 py-1 text-xs hover:border-slate-500"
+                  className="rounded-xl border border-white/70 bg-white/70 px-2 py-1 text-xs text-slate-600 shadow-[0_6px_16px_rgba(184,164,240,0.24)] transition hover:-translate-y-0.5 hover:shadow-[0_10px_22px_rgba(184,164,240,0.32)]"
                 >
                   위로
                 </button>
                 <button
                   type="button"
                   onClick={() => moveItem(target.id, 1)}
-                  className="rounded border border-slate-700 px-2 py-1 text-xs hover:border-slate-500"
+                  className="rounded-xl border border-white/70 bg-white/70 px-2 py-1 text-xs text-slate-600 shadow-[0_6px_16px_rgba(255,184,212,0.2)] transition hover:-translate-y-0.5 hover:shadow-[0_10px_22px_rgba(255,184,212,0.3)]"
                 >
                   아래로
                 </button>


### PR DESCRIPTION
## Summary
- refresh admin dashboard surfaces with pastel gradients, blur, and soft depth for isomorphic 3D feel
- add luminous gradient buttons and glowing list cards while keeping layout and text unchanged
- update global background to dreamy pastel gradients for atmospheric backdrop

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cfd03d1fc8326982f597ed24f3293)