### PR TITLE
Add admin manual upload endpoint for source files

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import { registerAdminMetricsRoutes } from './registerAdminMetricsRoutes.js';
 import { registerAdminIndexerRoutes } from './registerAdminIndexerRoutes.js';
 import { registerAdminDatabaseRoutes } from './registerAdminDatabaseRoutes.js';
 import { registerAdminSharedMediaRoutes } from './registerAdminSharedMediaRoutes.js';
+import { registerAdminManualUploadRoutes } from './registerAdminManualUploadRoutes.js';
 import { registerHighlightRoutes } from './highlights.js';
 import { registerImageProxyRoutes } from './imageProxy.js';
 import { registerSharedMediaRoutes } from './registerSharedMediaRoutes.js';
@@ -29,6 +30,7 @@ export async function registerApiRoutes(app: FastifyInstance): Promise<void> {
     await adminApp.register(registerAdminIndexerRoutes);
     await adminApp.register(registerAdminDatabaseRoutes);
     await adminApp.register(registerAdminSharedMediaRoutes);
+    await adminApp.register(registerAdminManualUploadRoutes);
   });
 
   // Redirect /api/docs → /docs so Swagger UI is reachable behind /api-only proxies.

--- a/backend/src/routes/registerAdminManualUploadRoutes.ts
+++ b/backend/src/routes/registerAdminManualUploadRoutes.ts
@@ -1,0 +1,210 @@
+import { FastifyInstance } from 'fastify';
+import { MultipartFile } from '@fastify/multipart';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+import { getSourcePath, validateFileType } from '../utils/fileUpload.js';
+import { sendError, sendSuccess } from '../utils/response.js';
+
+type ManualUploadType = 'Post' | 'Story';
+
+const postedAtRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+
+function parsePostedAt(value: string): { date: Date; timestampBase: string } | null {
+  if (!postedAtRegex.test(value)) {
+    return null;
+  }
+
+  const [datePart, timePart] = value.split(' ');
+  const [year, month, day] = datePart.split('-').map(Number);
+  const [hour, minute, second] = timePart.split(':').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() + 1 !== month ||
+    date.getUTCDate() !== day ||
+    date.getUTCHours() !== hour ||
+    date.getUTCMinutes() !== minute ||
+    date.getUTCSeconds() !== second
+  ) {
+    return null;
+  }
+
+  const timestampBase = `${datePart}_${timePart.replace(/:/g, '-')}`;
+  return { date, timestampBase };
+}
+
+function resolveFileExtension(file: MultipartFile): string {
+  const extFromName = path.extname(file.filename ?? '');
+  return extFromName || '';
+}
+
+function resolveType(value?: string): ManualUploadType | null {
+  if (value === 'Post' || value === 'Story') {
+    return value;
+  }
+  return null;
+}
+
+export async function registerAdminManualUploadRoutes(app: FastifyInstance): Promise<void> {
+  app.post(
+    '/api/admin/manual-upload',
+    {
+      schema: {
+        tags: ['AdminManualUpload'],
+        summary: 'Manual upload to source directory',
+        consumes: ['multipart/form-data'],
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: true },
+              data: {
+                type: 'object',
+                properties: {
+                  accountId: { type: 'string' },
+                  postedAt: { type: 'string' },
+                  type: { type: 'string', enum: ['Post', 'Story'] },
+                  savedFiles: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        filename: { type: 'string' },
+                        filepath: { type: 'string' }
+                      },
+                      required: ['filename', 'filepath']
+                    }
+                  },
+                  captionFile: { type: ['string', 'null'] },
+                  metadataFile: { type: ['string', 'null'] }
+                },
+                required: ['accountId', 'postedAt', 'type', 'savedFiles']
+              }
+            },
+            required: ['success', 'data']
+          }
+        }
+      }
+    },
+    async (request, reply) => {
+      const parts = request.parts();
+      const files: Array<{ file: MultipartFile; buffer: Buffer }> = [];
+      let accountId: string | undefined;
+      let postedAt: string | undefined;
+      let type: ManualUploadType | null = null;
+      let caption: string | undefined;
+
+      for await (const part of parts) {
+        if (part.type === 'file') {
+          if (part.fieldname !== 'files') {
+            return sendError(reply, 'Unexpected file field name', 400, 'BAD_REQUEST');
+          }
+          const buffer = await part.toBuffer();
+          files.push({ file: part as MultipartFile, buffer });
+          continue;
+        }
+
+        if (part.type === 'field') {
+          const value = (part as { value?: string }).value ?? '';
+          switch (part.fieldname) {
+            case 'accountId':
+              accountId = value;
+              break;
+            case 'postedAt':
+              postedAt = value;
+              break;
+            case 'type':
+              type = resolveType(value);
+              break;
+            case 'caption':
+              caption = value;
+              break;
+            default:
+              break;
+          }
+        }
+      }
+
+      if (!accountId) {
+        return sendError(reply, 'accountId is required', 400, 'BAD_REQUEST');
+      }
+
+      if (!postedAt) {
+        return sendError(reply, 'postedAt is required', 400, 'BAD_REQUEST');
+      }
+
+      const parsedPostedAt = parsePostedAt(postedAt);
+      if (!parsedPostedAt) {
+        return sendError(reply, 'postedAt must match yyyy-MM-dd hh:mm:ss', 400, 'BAD_REQUEST');
+      }
+
+      if (!type) {
+        return sendError(reply, 'type must be Post or Story', 400, 'BAD_REQUEST');
+      }
+
+      if (files.length === 0) {
+        return sendError(reply, 'files are required', 400, 'BAD_REQUEST');
+      }
+
+      const sourceDir = getSourcePath(accountId, parsedPostedAt.date);
+      await mkdir(sourceDir, { recursive: true });
+
+      const savedFiles: Array<{ filename: string; filepath: string }> = [];
+      const totalFiles = files.length;
+
+      for (const [index, entry] of files.entries()) {
+        const validation = validateFileType(entry.file.mimetype, entry.buffer.length);
+        if (!validation.valid) {
+          return sendError(reply, validation.error || 'Invalid file', 400, 'BAD_REQUEST');
+        }
+
+        const ext = resolveFileExtension(entry.file);
+        const fileSuffix =
+          totalFiles === 1
+            ? `_UTC${ext}`
+            : `_UTC_${index + 1}${ext}`;
+        const filename = `${parsedPostedAt.timestampBase}${fileSuffix}`;
+        const filepath = path.join(sourceDir, filename);
+        await writeFile(filepath, entry.buffer);
+        savedFiles.push({ filename, filepath });
+      }
+
+      let captionFile: string | null = null;
+      if (caption !== undefined) {
+        const filename = `${parsedPostedAt.timestampBase}_UTC.txt`;
+        const filepath = path.join(sourceDir, filename);
+        await writeFile(filepath, caption);
+        captionFile = filepath;
+      }
+
+      const metadataFilename = `${parsedPostedAt.timestampBase}_UTC.json`;
+      const metadataPath = path.join(sourceDir, metadataFilename);
+      await writeFile(
+        metadataPath,
+        JSON.stringify(
+          {
+            instaloader: {
+              node_type: type === 'Story' ? 'StoryItem' : 'Post'
+            }
+          },
+          null,
+          2
+        )
+      );
+
+      return sendSuccess(reply, {
+        accountId,
+        postedAt,
+        type,
+        savedFiles,
+        captionFile,
+        metadataFile: metadataPath
+      });
+    }
+  );
+}

--- a/backend/src/utils/fileUpload.ts
+++ b/backend/src/utils/fileUpload.ts
@@ -52,6 +52,11 @@ export function getUploadPath(date: Date = new Date()): string {
   return path.join(dataRoot, 'uploaded', yyyyMMdd);
 }
 
+export function getSourcePath(accountId: string, _date: Date = new Date()): string {
+  const dataRoot = process.env.DATA_ROOT ?? '/data';
+  return path.join(dataRoot, 'source', accountId);
+}
+
 export async function saveUploadedFile(
   file: MultipartFile,
   filename: string


### PR DESCRIPTION
### Motivation

- Provide an admin-only HTTP endpoint to manually upload media into the repository's source layout so operator-provided posts/stories can be ingested.
- Ensure server-side validation of multipart fields and reuse existing file-type rules to avoid duplicate validation logic.
- Persist media, caption, and metadata files under `/data/source/<accountId>/` using a deterministic UTC timestamped filename pattern.

### Description

- Added `POST /api/admin/manual-upload` implemented in `backend/src/routes/registerAdminManualUploadRoutes.ts` that parses multipart form fields `accountId`, `postedAt`, `type`, optional `caption`, and `files` (multi-file) and returns a summary of saved files.
- Implemented `postedAt` validation using a strict `yyyy-MM-dd hh:mm:ss` regex and UTC `Date` parsing to ensure exact timestamp fidelity and used `type` limited to `Post|Story`.
- Reused `validateFileType` from `backend/src/utils/fileUpload.ts` to validate image/video types and sizes before saving files.
- Persisted files into `/data/source/<accountId>/` using `YYYY-MM-DD_HH-MM-SS_UTC_<index>.<ext>` naming (single file uses `_UTC.<ext>`), wrote caption as `_UTC.txt` when present, and wrote `_UTC.json` metadata containing `instaloader.node_type` set to `StoryItem` for `Story` or `Post` for `Post`.
- Added `getSourcePath(accountId, date)` helper to `backend/src/utils/fileUpload.ts` and registered the new admin route in `backend/src/routes/index.ts`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981a9deef9c8326a5873721cfc4283b)