### PR TITLE
Allow api source volume writes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       DATA_ROOT: /data
       REDIS_URL: redis://redis:6379
     volumes:
-      - /mnt/volume1/fromistargram/data/source:/data/source:ro
+      - /mnt/volume1/fromistargram/data/source:/data/source
       - /mnt/volume1/fromistargram/data/result:/result
       - /mnt/volume1/fromistargram/data/uploaded:/data/uploaded
     ports:


### PR DESCRIPTION
### Motivation
- Allow the `api` service to write to the mounted source directory when the service needs to modify or create files under `/data/source`.

### Description
- Removed the `:ro` (read-only) flag from the `api` service source volume mount in `docker-compose.yml` so `/mnt/volume1/fromistargram/data/source` is mounted writable by the `api` container.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981aa27729083269b8e846e8e113855)