### PR TITLE
Adjust Authentik max_age to 60 minutes and accept ISO8601 postedAt in admin manual upload

### DIFF
--- a/backend/src/routes/registerAdminManualUploadRoutes.ts
+++ b/backend/src/routes/registerAdminManualUploadRoutes.ts
@@ -7,34 +7,21 @@ import { sendError, sendSuccess } from '../utils/response.js';
 
 type ManualUploadType = 'Post' | 'Story';
 
-const postedAtRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
-
 function parsePostedAt(value: string): { date: Date; timestampBase: string } | null {
-  if (!postedAtRegex.test(value)) {
-    return null;
-  }
-
-  const [datePart, timePart] = value.split(' ');
-  const [year, month, day] = datePart.split('-').map(Number);
-  const [hour, minute, second] = timePart.split(':').map(Number);
-  const date = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  const date = new Date(value);
 
   if (Number.isNaN(date.getTime())) {
     return null;
   }
 
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() + 1 !== month ||
-    date.getUTCDate() !== day ||
-    date.getUTCHours() !== hour ||
-    date.getUTCMinutes() !== minute ||
-    date.getUTCSeconds() !== second
-  ) {
-    return null;
-  }
+  const yyyy = date.getUTCFullYear();
+  const MM = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(date.getUTCDate()).padStart(2, '0');
+  const HH = String(date.getUTCHours()).padStart(2, '0');
+  const mm = String(date.getUTCMinutes()).padStart(2, '0');
+  const ss = String(date.getUTCSeconds()).padStart(2, '0');
 
-  const timestampBase = `${datePart}_${timePart.replace(/:/g, '-')}`;
+  const timestampBase = `${yyyy}-${MM}-${dd}_${HH}-${mm}-${ss}`;
   return { date, timestampBase };
 }
 
@@ -140,7 +127,7 @@ export async function registerAdminManualUploadRoutes(app: FastifyInstance): Pro
 
       const parsedPostedAt = parsePostedAt(postedAt);
       if (!parsedPostedAt) {
-        return sendError(reply, 'postedAt must match yyyy-MM-dd hh:mm:ss', 400, 'BAD_REQUEST');
+        return sendError(reply, 'postedAt must be a valid ISO 8601 datetime', 400, 'BAD_REQUEST');
       }
 
       if (!type) {

--- a/frontend/src/lib/auth/context.tsx
+++ b/frontend/src/lib/auth/context.tsx
@@ -43,6 +43,7 @@ export const AUTH_STORAGE_KEY = 'fromistargram.auth.session';
 const STATE_KEY = 'fromistargram.auth.state';
 const NONCE_KEY = 'fromistargram.auth.nonce';
 const CODE_VERIFIER_KEY = 'fromistargram.auth.code_verifier';
+const AUTH_MAX_AGE_SECONDS = 60 * 60;
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
@@ -191,8 +192,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         authorizeUrl.searchParams.set('prompt', options.prompt);
       }
 
+      authorizeUrl.searchParams.set('max_age', String(AUTH_MAX_AGE_SECONDS));
+
       if (options?.force) {
-        authorizeUrl.searchParams.set('max_age', '0');
+        authorizeUrl.searchParams.set('prompt', 'login');
       }
 
       sessionStorage.setItem(STATE_KEY, stateValue);

--- a/frontend/src/routes/admin/AdminUploadsPage.tsx
+++ b/frontend/src/routes/admin/AdminUploadsPage.tsx
@@ -9,30 +9,12 @@ import { uploadAdminMedia } from '../../lib/api/admin/uploads';
 import type { AdminSharedMedia } from '../../lib/api/admin/types';
 import type { Account } from '../../lib/api/types';
 
-const DATETIME_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+const DEFAULT_POSTED_AT = '2026-03-13T12:04:27.000Z';
 
 const parsePostedAt = (input: string) => {
-  if (!DATETIME_REGEX.test(input)) {
-    return null;
-  }
-
-  const [datePart, timePart] = input.split(' ');
-  const [year, month, day] = datePart.split('-').map(Number);
-  const [hour, minute, second] = timePart.split(':').map(Number);
-  const parsed = new Date(`${datePart}T${timePart}`);
+  const parsed = new Date(input);
 
   if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-
-  if (
-    parsed.getFullYear() !== year ||
-    parsed.getMonth() + 1 !== month ||
-    parsed.getDate() !== day ||
-    parsed.getHours() !== hour ||
-    parsed.getMinutes() !== minute ||
-    parsed.getSeconds() !== second
-  ) {
     return null;
   }
 
@@ -43,7 +25,7 @@ const AdminUploadsPage = () => {
   const queryClient = useQueryClient();
   const [limit] = useState(50);
   const [accountId, setAccountId] = useState('');
-  const [postedAt, setPostedAt] = useState('');
+  const [postedAt, setPostedAt] = useState(DEFAULT_POSTED_AT);
   const [caption, setCaption] = useState('');
   const [postType, setPostType] = useState<'Post' | 'Story'>('Post');
   const [files, setFiles] = useState<File[]>([]);
@@ -113,7 +95,7 @@ const AdminUploadsPage = () => {
     onSuccess: () => {
       setFormError(null);
       setFormSuccess('업로드가 완료되었습니다.');
-      setPostedAt('');
+      setPostedAt(DEFAULT_POSTED_AT);
       setCaption('');
       setFiles([]);
       queryClient.invalidateQueries({ queryKey: [ADMIN_KEY, 'shared-media'] });
@@ -160,7 +142,7 @@ const AdminUploadsPage = () => {
 
     const parsedDate = parsePostedAt(postedAt);
     if (!parsedDate) {
-      setFormError('게시일시는 yyyy-MM-dd hh:mm:ss 형식으로 입력해 주세요.');
+      setFormError('게시일시는 ISO 8601 형식으로 입력해 주세요. (예: 2026-03-13T12:04:27.000Z)');
       return;
     }
 
@@ -235,12 +217,12 @@ const AdminUploadsPage = () => {
               </select>
             </label>
             <label className="flex flex-col gap-2 text-sm text-slate-300">
-              게시일시 (yyyy-MM-dd hh:mm:ss)
+              게시일시 (ISO 8601)
               <input
                 type="text"
                 value={postedAt}
                 onChange={(event) => setPostedAt(event.target.value)}
-                placeholder="2024-01-30 14:30:00"
+                placeholder="2026-03-13T12:04:27.000Z"
                 className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 focus:border-brand-400 focus:outline-none"
               />
             </label>


### PR DESCRIPTION
### Motivation
- Increase Authentik session validation window for admin flows to 60 minutes so `max_age` is explicitly set for authorize requests.
- Allow the admin manual-upload UI and backend to accept ISO 8601 datetimes (including `...Z`) and use the provided `2026-03-13T12:04:27.000Z` as the default posted time for manual uploads.

### Description
- Frontend: add `AUTH_MAX_AGE_SECONDS = 60 * 60` and set the authorize request `max_age` to `3600`; change `force` login to send `prompt=login` instead of `max_age=0` (file: `frontend/src/lib/auth/context.tsx`).
- Frontend: change admin manual-upload form to default `postedAt` to `2026-03-13T12:04:27.000Z`, accept ISO 8601 input, update label/placeholder and validation error text (file: `frontend/src/routes/admin/AdminUploadsPage.tsx`).
- Backend: update manual upload `parsePostedAt` to parse general ISO 8601 datetimes (using `new Date(value)`), produce UTC-based filename timestamp `YYYY-MM-DD_HH-mm-ss`, and update validation error messaging (file: `backend/src/routes/registerAdminManualUploadRoutes.ts`).

### Testing
- Ran TypeScript checks (`pnpm --filter @fromistargram/frontend lint` and `pnpm --filter @fromistargram/backend lint`), both succeeded.
- Started the frontend dev server and captured a screenshot of `/admin/uploads` with a mocked authenticated session to verify the updated `postedAt` placeholder and default, screenshot saved as an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4cba318448326bb9d11c4b1e31786)