### PR TITLE
Stop forcing Authentik prompt for admin login (fix double sign-in)

### DIFF
--- a/frontend/src/lib/auth/useAuthGuard.ts
+++ b/frontend/src/lib/auth/useAuthGuard.ts
@@ -20,7 +20,7 @@ export const useAuthGuard = () => {
 
     if (!auth.isAuthenticated) {
       sessionStorage.setItem(LOGIN_ATTEMPTED_KEY, 'true');
-      auth.login({ force: true });
+      auth.login();
     }
   }, [auth.isLoading, auth.isAuthenticated, auth.login]);
 

--- a/frontend/src/routes/admin/AdminGate.tsx
+++ b/frontend/src/routes/admin/AdminGate.tsx
@@ -27,7 +27,7 @@ const AdminGate = () => {
             <p className="text-sm text-red-400">{auth.error}</p>
           )}
           <button
-            onClick={() => auth.login({ force: true })}
+            onClick={() => auth.login()}
             className="rounded-lg bg-brand-500 px-6 py-2 text-white hover:bg-brand-600"
           >
             Authentik으로 로그인


### PR DESCRIPTION
### Motivation
- The admin entry points were forcing a fresh Authentik login (`prompt=login`) which caused users to be prompted twice instead of reusing an existing SSO session.

### Description
- Remove the forced login flag so admin login uses the normal authorization flow by changing `auth.login({ force: true })` to `auth.login()` in `frontend/src/routes/admin/AdminGate.tsx` and `frontend/src/lib/auth/useAuthGuard.ts`.

### Testing
- Ran `pnpm --filter @fromistargram/frontend lint` and `pnpm --filter @fromistargram/frontend build`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc7f22c7a883268dc7f2479b6a97f4)