### PR TITLE
Support optional id_token and simplify identity handling in auth flow

### DIFF
--- a/frontend/src/lib/auth/context.tsx
+++ b/frontend/src/lib/auth/context.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { loadAuthentikConfig, type AuthentikConfig } from './config';
 import {
+  isTokenExpired,
   parseIdToken,
   type ParsedIdToken,
   exchangeCodeForTokens,
@@ -53,6 +54,10 @@ const resolveIdentity = (idToken: string | undefined, fallbackIdToken?: string) 
   const resolvedIdToken = idToken ?? fallbackIdToken;
 
   if (!resolvedIdToken) {
+    return null;
+  }
+
+  if (isTokenExpired(resolvedIdToken)) {
     return null;
   }
 
@@ -334,7 +339,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
       const stored = loadStoredSession();
 
-      if (!stored || stored.expiresAt <= Date.now()) {
+      if (!stored || stored.expiresAt <= Date.now() || isTokenExpired(stored.idToken)) {
         // Try to refresh token if refresh token exists
         if (stored?.refreshToken) {
           try {
@@ -458,7 +463,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return false;
     }
 
-    return true;
+    return !isTokenExpired(state.idToken.raw);
   }, [state.token, state.idToken, state.expiresAt]);
 
   const value = useMemo<AuthContextValue>(

--- a/frontend/src/lib/auth/context.tsx
+++ b/frontend/src/lib/auth/context.tsx
@@ -10,8 +10,6 @@ import {
 } from 'react';
 import { loadAuthentikConfig, type AuthentikConfig } from './config';
 import {
-  decodeJwt,
-  isTokenExpired,
   parseIdToken,
   type ParsedIdToken,
   exchangeCodeForTokens,
@@ -49,6 +47,24 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 const resolveExpiresAt = (expiresIn: number): number => {
   return Date.now() + expiresIn * 1000;
+};
+
+const resolveIdentity = (idToken: string | undefined, fallbackIdToken?: string) => {
+  const resolvedIdToken = idToken ?? fallbackIdToken;
+
+  if (!resolvedIdToken) {
+    return null;
+  }
+
+  const parsedIdToken = parseIdToken(resolvedIdToken);
+  if (!parsedIdToken) {
+    return null;
+  }
+
+  return {
+    idToken: resolvedIdToken,
+    parsedIdToken
+  };
 };
 
 const tryParseAuthorizationCode = (
@@ -248,9 +264,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           );
 
           const expiresAt = resolveExpiresAt(tokenResponse.expires_in);
-          const parsed = parseIdToken(tokenResponse.id_token);
+          const identity = resolveIdentity(tokenResponse.id_token);
 
-          if (!parsed) {
+          if (!identity) {
             cleanOAuthParamsFromUrl();
             persistSession(null);
             sessionStorage.removeItem(STATE_KEY);
@@ -264,7 +280,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             return;
           }
 
-          if (nonceValue && parsed.nonce && parsed.nonce !== nonceValue) {
+          if (nonceValue && identity.parsedIdToken.nonce && identity.parsedIdToken.nonce !== nonceValue) {
             cleanOAuthParamsFromUrl();
             persistSession(null);
             sessionStorage.removeItem(STATE_KEY);
@@ -280,7 +296,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
           const session: StoredSession = {
             accessToken: tokenResponse.access_token,
-            idToken: tokenResponse.id_token,
+            idToken: identity.idToken,
             refreshToken: tokenResponse.refresh_token,
             expiresAt,
             scope: tokenResponse.scope,
@@ -295,7 +311,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
           setState({
             token: tokenResponse.access_token,
-            idToken: parsed,
+            idToken: identity.parsedIdToken,
             expiresAt,
             isLoading: false,
             error: null
@@ -318,7 +334,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
       const stored = loadStoredSession();
 
-      if (!stored || stored.expiresAt <= Date.now() || isTokenExpired(stored.idToken)) {
+      if (!stored || stored.expiresAt <= Date.now()) {
         // Try to refresh token if refresh token exists
         if (stored?.refreshToken) {
           try {
@@ -329,12 +345,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             );
 
             const expiresAt = resolveExpiresAt(tokenResponse.expires_in);
-            const parsed = parseIdToken(tokenResponse.id_token);
+            const identity = resolveIdentity(tokenResponse.id_token, stored.idToken);
 
-            if (parsed) {
+            if (identity) {
               const session: StoredSession = {
                 accessToken: tokenResponse.access_token,
-                idToken: tokenResponse.id_token,
+                idToken: identity.idToken,
                 refreshToken: tokenResponse.refresh_token ?? stored.refreshToken,
                 expiresAt,
                 scope: tokenResponse.scope,
@@ -344,7 +360,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
               persistSession(session);
               setState({
                 token: tokenResponse.access_token,
-                idToken: parsed,
+                idToken: identity.parsedIdToken,
                 expiresAt,
                 isLoading: false,
                 error: null
@@ -403,12 +419,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         );
 
         const expiresAt = resolveExpiresAt(tokenResponse.expires_in);
-        const parsed = parseIdToken(tokenResponse.id_token);
+        const identity = resolveIdentity(tokenResponse.id_token, stored.idToken);
 
-        if (parsed) {
+        if (identity) {
           const session: StoredSession = {
             accessToken: tokenResponse.access_token,
-            idToken: tokenResponse.id_token,
+            idToken: identity.idToken,
             refreshToken: tokenResponse.refresh_token ?? stored.refreshToken,
             expiresAt,
             scope: tokenResponse.scope,
@@ -419,7 +435,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           setState((prev) => ({
             ...prev,
             token: tokenResponse.access_token,
-            idToken: parsed,
+            idToken: identity.parsedIdToken,
             expiresAt
           }));
         }
@@ -442,7 +458,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       return false;
     }
 
-    return !isTokenExpired(state.idToken.raw);
+    return true;
   }, [state.token, state.idToken, state.expiresAt]);
 
   const value = useMemo<AuthContextValue>(

--- a/frontend/src/lib/auth/token.ts
+++ b/frontend/src/lib/auth/token.ts
@@ -83,7 +83,7 @@ export const parseIdToken = (token: string): ParsedIdToken | null => {
 
 export interface TokenResponse {
   access_token: string;
-  id_token: string;
+  id_token?: string;
   refresh_token?: string;
   expires_in: number;
   token_type: string;

--- a/frontend/src/lib/auth/useAuthGuard.ts
+++ b/frontend/src/lib/auth/useAuthGuard.ts
@@ -20,7 +20,7 @@ export const useAuthGuard = () => {
 
     if (!auth.isAuthenticated) {
       sessionStorage.setItem(LOGIN_ATTEMPTED_KEY, 'true');
-      auth.login({ force: true });
+      auth.login();
     }
   }, [auth.isLoading, auth.isAuthenticated, auth.login]);
 

--- a/frontend/src/routes/admin/AdminGate.tsx
+++ b/frontend/src/routes/admin/AdminGate.tsx
@@ -27,7 +27,7 @@ const AdminGate = () => {
             <p className="text-sm text-red-400">{auth.error}</p>
           )}
           <button
-            onClick={() => auth.login({ force: true })}
+            onClick={() => auth.login()}
             className="rounded-lg bg-brand-500 px-6 py-2 text-white hover:bg-brand-600"
           >
             Authentik으로 로그인


### PR DESCRIPTION
### Motivation

- Make the authentication flow resilient when the authorization server does not return an `id_token` during refresh or code exchange. 
- Avoid brittle expiration checks based on parsing failure and reduce reliance on a separate `isTokenExpired` check. 
- Remove forced-login UX behavior in guards to allow manual user-initiated login from UI components.

### Description

- Add `resolveIdentity` to centralize resolving and parsing an `id_token`, falling back to a stored token when the response omits `id_token`. 
- Make `TokenResponse.id_token` optional and update token exchange/refresh flows to use `resolveIdentity` so sessions persist when `id_token` is missing but a previous token is available. 
- Replace scattered `parseIdToken` usage with the `resolveIdentity` result and update stored session fields to use the resolved `idToken` and parsed token. 
- Simplify authentication checks by removing the `isTokenExpired` dependency and always treating a present, unexpired session as authenticated; also remove forced `force: true` login calls from `useAuthGuard` and `AdminGate` to rely on the normal login flow.

### Testing

- Ran TypeScript type-check and frontend build via `yarn build`, which completed successfully. 
- Ran unit tests with `yarn test`, and all tests passed. 
- Ran linter `yarn lint` with no new errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc7f22c7a883268dc7f2479b6a97f4)