### PR TITLE
[codex] Allow wildcard preview CORS origins

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import swaggerUi from '@fastify/swagger-ui';
 import pino from 'pino';
 import { registerApiRoutes } from './routes/index.js';
 import { csrfProtection } from './utils/csrf.js';
+import { getAllowedOrigins, isOriginAllowed } from './utils/origin.js';
 
 export type BuildServerOptions = FastifyServerOptions & {
   enablePrettyLogs?: boolean;
@@ -30,12 +31,9 @@ export async function buildServer(options: BuildServerOptions = {}): Promise<Fas
   });
 
   // CORS configuration
-  // Set CORS_ORIGINS env var with comma-separated domains (e.g., "https://example.com,https://app.example.com")
+  // Set CORS_ORIGINS env var with comma-separated domains (e.g., "https://example.com,https://*.example.com")
   // If not set, defaults to restrictive mode in production
-  const corsOrigins = process.env.CORS_ORIGINS;
-  const allowedOrigins = corsOrigins
-    ? corsOrigins.split(',').map((origin) => origin.trim()).filter(Boolean)
-    : [];
+  const allowedOrigins = getAllowedOrigins();
 
   await app.register(cors, {
     origin: (origin, callback) => {
@@ -45,23 +43,11 @@ export async function buildServer(options: BuildServerOptions = {}): Promise<Fas
         return;
       }
 
-      // If CORS_ORIGINS is configured, check against whitelist
-      if (allowedOrigins.length > 0) {
-        if (allowedOrigins.includes(origin)) {
-          callback(null, true);
-        } else {
-          callback(new Error('CORS not allowed'), false);
-        }
-        return;
-      }
-
-      // Development fallback: allow localhost origins
-      if (origin.includes('localhost') || origin.includes('127.0.0.1')) {
+      if (isOriginAllowed(origin, allowedOrigins)) {
         callback(null, true);
         return;
       }
 
-      // No CORS_ORIGINS set and not localhost - deny in production
       callback(new Error('CORS not allowed'), false);
     },
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],

--- a/backend/src/utils/csrf.ts
+++ b/backend/src/utils/csrf.ts
@@ -1,4 +1,5 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
+import { getAllowedOrigins, isOriginAllowed } from './origin.js';
 
 /**
  * CSRF Protection middleware
@@ -11,27 +12,6 @@ import { FastifyRequest, FastifyReply } from 'fastify';
  */
 
 const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
-
-function getAllowedOrigins(): string[] {
-  const corsOrigins = process.env.CORS_ORIGINS;
-  if (!corsOrigins) {
-    return [];
-  }
-  return corsOrigins.split(',').map((origin) => origin.trim()).filter(Boolean);
-}
-
-function isOriginAllowed(origin: string | undefined, allowedOrigins: string[]): boolean {
-  if (!origin) {
-    return false;
-  }
-
-  // If no origins configured, allow localhost for development
-  if (allowedOrigins.length === 0) {
-    return origin.includes('localhost') || origin.includes('127.0.0.1');
-  }
-
-  return allowedOrigins.includes(origin);
-}
 
 /**
  * Validate Origin header for state-changing requests

--- a/backend/src/utils/csrf.ts
+++ b/backend/src/utils/csrf.ts
@@ -12,6 +12,7 @@ import { getAllowedOrigins, isOriginAllowed } from './origin.js';
  */
 
 const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+const ALLOWED_ORIGINS = getAllowedOrigins();
 
 /**
  * Validate Origin header for state-changing requests
@@ -43,11 +44,9 @@ export async function csrfProtection(
     return;
   }
 
-  const allowedOrigins = getAllowedOrigins();
-
   // Check origin header first
   if (origin) {
-    if (!isOriginAllowed(origin, allowedOrigins)) {
+    if (!isOriginAllowed(origin, ALLOWED_ORIGINS)) {
       request.log.warn({ origin }, 'CSRF: Origin not allowed');
       reply.code(403).send({ error: 'Origin not allowed' });
       return;
@@ -59,7 +58,7 @@ export async function csrfProtection(
   if (referer) {
     try {
       const refererOrigin = new URL(referer).origin;
-      if (!isOriginAllowed(refererOrigin, allowedOrigins)) {
+      if (!isOriginAllowed(refererOrigin, ALLOWED_ORIGINS)) {
         request.log.warn({ referer }, 'CSRF: Referer origin not allowed');
         reply.code(403).send({ error: 'Origin not allowed' });
         return;

--- a/backend/src/utils/origin.test.ts
+++ b/backend/src/utils/origin.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { isOriginAllowed } from './origin.js';
+
+describe('isOriginAllowed', () => {
+  it('allows exact configured origins', () => {
+    expect(isOriginAllowed('https://fromistargram.ddunddun.shop', [
+      'https://fromistargram.ddunddun.shop'
+    ])).toBe(true);
+  });
+
+  it('allows wildcard subdomains', () => {
+    expect(isOriginAllowed('https://42.fromistargram.ddunddun.shop', [
+      'https://*.fromistargram.ddunddun.shop'
+    ])).toBe(true);
+  });
+
+  it('does not allow the apex host for wildcard entries', () => {
+    expect(isOriginAllowed('https://fromistargram.ddunddun.shop', [
+      'https://*.fromistargram.ddunddun.shop'
+    ])).toBe(false);
+  });
+
+  it('does not allow sibling domains that only contain the allowed suffix', () => {
+    expect(isOriginAllowed('https://42.fromistargram.ddunddun.shop.evil.test', [
+      'https://*.fromistargram.ddunddun.shop'
+    ])).toBe(false);
+  });
+
+  it('requires the same protocol for wildcard entries', () => {
+    expect(isOriginAllowed('http://42.fromistargram.ddunddun.shop', [
+      'https://*.fromistargram.ddunddun.shop'
+    ])).toBe(false);
+  });
+
+  it('falls back to localhost when no origins are configured', () => {
+    expect(isOriginAllowed('http://localhost:5173', [])).toBe(true);
+    expect(isOriginAllowed('http://127.0.0.1:5173', [])).toBe(true);
+    expect(isOriginAllowed('https://not-localhost.example', [])).toBe(false);
+  });
+});

--- a/backend/src/utils/origin.ts
+++ b/backend/src/utils/origin.ts
@@ -1,0 +1,75 @@
+const LOCALHOST_HOSTS = new Set(['localhost', '127.0.0.1']);
+
+export function getAllowedOrigins(): string[] {
+  const corsOrigins = process.env.CORS_ORIGINS;
+  if (!corsOrigins) {
+    return [];
+  }
+  return corsOrigins.split(',').map((origin) => origin.trim()).filter(Boolean);
+}
+
+export function isOriginAllowed(origin: string | undefined, allowedOrigins: string[]): boolean {
+  if (!origin) {
+    return false;
+  }
+
+  if (allowedOrigins.length === 0) {
+    return isLocalhostOrigin(origin);
+  }
+
+  return allowedOrigins.some((allowedOrigin) => matchesAllowedOrigin(origin, allowedOrigin));
+}
+
+function isLocalhostOrigin(origin: string): boolean {
+  try {
+    const { hostname } = new URL(origin);
+    return LOCALHOST_HOSTS.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+function matchesAllowedOrigin(origin: string, allowedOrigin: string): boolean {
+  const normalizedOrigin = normalizeOrigin(origin);
+  const normalizedAllowedOrigin = normalizeOrigin(allowedOrigin);
+  if (normalizedOrigin && normalizedAllowedOrigin && normalizedOrigin === normalizedAllowedOrigin) {
+    return true;
+  }
+
+  if (matchesWildcardOrigin(origin, allowedOrigin)) {
+    return true;
+  }
+
+  return origin === allowedOrigin;
+}
+
+function normalizeOrigin(origin: string): string | null {
+  try {
+    return new URL(origin).origin;
+  } catch {
+    return null;
+  }
+}
+
+function matchesWildcardOrigin(origin: string, allowedOrigin: string): boolean {
+  const wildcardMatch = allowedOrigin.match(/^([a-z][a-z\d+.-]*:\/\/)\*\.(.+)$/i);
+  if (!wildcardMatch) {
+    return false;
+  }
+
+  try {
+    const originUrl = new URL(origin);
+    const allowedBaseUrl = new URL(`${wildcardMatch[1]}${wildcardMatch[2]}`);
+    const originHostname = originUrl.hostname.toLowerCase();
+    const allowedHostname = allowedBaseUrl.hostname.toLowerCase();
+
+    return (
+      originUrl.protocol === allowedBaseUrl.protocol &&
+      originUrl.port === allowedBaseUrl.port &&
+      originHostname !== allowedHostname &&
+      originHostname.endsWith(`.${allowedHostname}`)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/backend/src/utils/origin.ts
+++ b/backend/src/utils/origin.ts
@@ -1,4 +1,5 @@
 const LOCALHOST_HOSTS = new Set(['localhost', '127.0.0.1']);
+const WILDCARD_ORIGIN_PATTERN = /^([a-z][a-z\d+.-]*:\/\/)\*\.(.+)$/i;
 
 export function getAllowedOrigins(): string[] {
   const corsOrigins = process.env.CORS_ORIGINS;
@@ -13,30 +14,34 @@ export function isOriginAllowed(origin: string | undefined, allowedOrigins: stri
     return false;
   }
 
+  const originUrl = parseUrl(origin);
+  const normalizedOrigin = originUrl?.origin ?? null;
+
   if (allowedOrigins.length === 0) {
-    return isLocalhostOrigin(origin);
+    return isLocalhostOrigin(originUrl);
   }
 
-  return allowedOrigins.some((allowedOrigin) => matchesAllowedOrigin(origin, allowedOrigin));
+  return allowedOrigins.some((allowedOrigin) =>
+    matchesAllowedOrigin(origin, originUrl, normalizedOrigin, allowedOrigin)
+  );
 }
 
-function isLocalhostOrigin(origin: string): boolean {
-  try {
-    const { hostname } = new URL(origin);
-    return LOCALHOST_HOSTS.has(hostname);
-  } catch {
-    return false;
-  }
+function isLocalhostOrigin(originUrl: URL | null): boolean {
+  return originUrl ? LOCALHOST_HOSTS.has(originUrl.hostname) : false;
 }
 
-function matchesAllowedOrigin(origin: string, allowedOrigin: string): boolean {
-  const normalizedOrigin = normalizeOrigin(origin);
+function matchesAllowedOrigin(
+  origin: string,
+  originUrl: URL | null,
+  normalizedOrigin: string | null,
+  allowedOrigin: string
+): boolean {
   const normalizedAllowedOrigin = normalizeOrigin(allowedOrigin);
   if (normalizedOrigin && normalizedAllowedOrigin && normalizedOrigin === normalizedAllowedOrigin) {
     return true;
   }
 
-  if (matchesWildcardOrigin(origin, allowedOrigin)) {
+  if (originUrl && matchesWildcardOrigin(originUrl, allowedOrigin)) {
     return true;
   }
 
@@ -44,21 +49,24 @@ function matchesAllowedOrigin(origin: string, allowedOrigin: string): boolean {
 }
 
 function normalizeOrigin(origin: string): string | null {
+  return parseUrl(origin)?.origin ?? null;
+}
+
+function parseUrl(url: string): URL | null {
   try {
-    return new URL(origin).origin;
+    return new URL(url);
   } catch {
     return null;
   }
 }
 
-function matchesWildcardOrigin(origin: string, allowedOrigin: string): boolean {
-  const wildcardMatch = allowedOrigin.match(/^([a-z][a-z\d+.-]*:\/\/)\*\.(.+)$/i);
+function matchesWildcardOrigin(originUrl: URL, allowedOrigin: string): boolean {
+  const wildcardMatch = allowedOrigin.match(WILDCARD_ORIGIN_PATTERN);
   if (!wildcardMatch) {
     return false;
   }
 
   try {
-    const originUrl = new URL(origin);
     const allowedBaseUrl = new URL(`${wildcardMatch[1]}${wildcardMatch[2]}`);
     const originHostname = originUrl.hostname.toLowerCase();
     const allowedHostname = allowedBaseUrl.hostname.toLowerCase();


### PR DESCRIPTION
## Summary
- Add shared backend origin matching for CORS and CSRF checks.
- Support `https://*.fromistargram.ddunddun.shop` style preview origins while keeping exact-origin matching.
- Add unit coverage for wildcard subdomains, apex-host exclusion, protocol matching, suffix spoofing, and localhost fallback.

## Why
Frontend PR previews are served from subdomains like `https://42.fromistargram.ddunddun.shop`, but the API only allowed exact origins from `CORS_ORIGINS`. That caused preview API calls to fail with missing CORS headers.

## Validation
- `pnpm --filter @fromistargram/backend lint`
- `pnpm --filter @fromistargram/backend test`