### PR TITLE
Add mobile highlight ingest

### DIFF
--- a/backend/src/routes/highlights.ts
+++ b/backend/src/routes/highlights.ts
@@ -43,10 +43,11 @@ export async function registerHighlightRoutes(app: FastifyInstance) {
                                                 filename: { type: 'string' },
                                                 mime: { type: 'string' },
                                                 orderIndex: { type: 'number' },
+                                                rawUrl: { type: 'string' },
                                                 url: { type: 'string' },
                                                 thumbnailUrl: { type: 'string' }
                                             },
-                                            required: ['id', 'filename', 'mime', 'orderIndex', 'url', 'thumbnailUrl']
+                                            required: ['id', 'filename', 'mime', 'orderIndex', 'rawUrl', 'url', 'thumbnailUrl']
                                         },
                                         media: {
                                             type: 'array',
@@ -57,10 +58,11 @@ export async function registerHighlightRoutes(app: FastifyInstance) {
                                                     filename: { type: 'string' },
                                                     mime: { type: 'string' },
                                                     orderIndex: { type: 'number' },
+                                                    rawUrl: { type: 'string' },
                                                     url: { type: 'string' },
                                                     thumbnailUrl: { type: 'string' }
                                                 },
-                                                required: ['id', 'filename', 'mime', 'orderIndex', 'url', 'thumbnailUrl']
+                                                required: ['id', 'filename', 'mime', 'orderIndex', 'rawUrl', 'url', 'thumbnailUrl']
                                             }
                                         }
                                     },
@@ -92,9 +94,10 @@ export async function registerHighlightRoutes(app: FastifyInstance) {
                 const mapMedia = (m: HighlightMedia) => {
                     const source = `local:///source/${accountId}/${m.filename}`;
                     const mediaUrl = buildHighlightMediaUrl(accountId, m.filename);
+                    const isVideo = m.mime.startsWith('video/');
 
-                    // Full URL (Original or high quality)
-                    const url = buildImagorUrl(source) ?? mediaUrl;
+                    // Full URL for images, raw stream URL for videos.
+                    const url = isVideo ? mediaUrl : buildImagorUrl(source) ?? mediaUrl;
 
                     // Thumbnail URL (Resized)
                     const thumbnailUrl = buildImagorUrl(source, {
@@ -103,6 +106,7 @@ export async function registerHighlightRoutes(app: FastifyInstance) {
 
                     return {
                         ...m,
+                        rawUrl: mediaUrl,
                         url,
                         thumbnailUrl
                     };

--- a/backend/src/routes/highlights.ts
+++ b/backend/src/routes/highlights.ts
@@ -4,6 +4,12 @@ import { prisma } from '../db/client.js';
 import { buildImagorUrl } from '../utils/imagor.js';
 import { sendSuccess } from '../utils/response.js';
 
+function buildHighlightMediaUrl(accountId: string, filename: string): string {
+    const safeAccount = encodeURIComponent(accountId);
+    const safePath = filename.split(/[\\/]/g).map((part) => encodeURIComponent(part)).join('/');
+    return `/api/media/${safeAccount}/${safePath}`;
+}
+
 export async function registerHighlightRoutes(app: FastifyInstance) {
     app.get<{ Params: { accountId: string } }>(
         '/api/accounts/:accountId/highlights',
@@ -84,15 +90,16 @@ export async function registerHighlightRoutes(app: FastifyInstance) {
             const data = highlights.map((highlight) => {
                 // Map media items to include signed URLs
                 const mapMedia = (m: HighlightMedia) => {
-                    const source = `local:///${accountId}/${m.filename}`;
+                    const source = `local:///source/${accountId}/${m.filename}`;
+                    const mediaUrl = buildHighlightMediaUrl(accountId, m.filename);
 
                     // Full URL (Original or high quality)
-                    const url = buildImagorUrl(source) ?? '';
+                    const url = buildImagorUrl(source) ?? mediaUrl;
 
                     // Thumbnail URL (Resized)
                     const thumbnailUrl = buildImagorUrl(source, {
                         resize: { width: 640, type: 'fit' }
-                    }) ?? '';
+                    }) ?? mediaUrl;
 
                     return {
                         ...m,

--- a/backend/src/routes/registerMobileIngestRoutes.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.ts
@@ -81,7 +81,7 @@ function normalizeAccountName(value?: string): string | null {
 function normalizeHighlightTitle(value?: string): string | null {
   const normalized = (value ?? '')
     .trim()
-    .replace(/[\\/]+/g, '_')
+    .replace(/[^a-zA-Z0-9._-]+/g, '_')
     .replace(/^\.+$/g, '')
     .replace(/^_+|_+$/g, '');
 

--- a/backend/src/routes/registerMobileIngestRoutes.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.ts
@@ -17,9 +17,9 @@ import {
 import { formatDateToYYYYMMDD } from '../utils/dateFormat.js';
 import { sendError, sendSuccess } from '../utils/response.js';
 
-type MobileIngestContentType = 'POST' | 'STORY' | 'REEL';
+type MobileIngestContentType = 'POST' | 'STORY' | 'REEL' | 'HIGHLIGHT';
 type SourceUploadType = 'Post' | 'Story';
-type StorageTarget = 'SOURCE' | 'SHARED';
+type StorageTarget = 'SOURCE' | 'SHARED' | 'HIGHLIGHT';
 
 type BufferedUploadFile = {
   file: MultipartFile;
@@ -78,8 +78,18 @@ function normalizeAccountName(value?: string): string | null {
   return normalized || null;
 }
 
+function normalizeHighlightTitle(value?: string): string | null {
+  const normalized = (value ?? '')
+    .trim()
+    .replace(/[\\/]+/g, '_')
+    .replace(/^\.+$/g, '')
+    .replace(/^_+|_+$/g, '');
+
+  return normalized || null;
+}
+
 function parseContentType(value?: string): MobileIngestContentType {
-  if (value === 'STORY' || value === 'REEL' || value === 'POST') {
+  if (value === 'STORY' || value === 'REEL' || value === 'POST' || value === 'HIGHLIGHT') {
     return value;
   }
 
@@ -158,12 +168,14 @@ async function readMobileIngestForm(request: FastifyRequest): Promise<{
   uploadedAt?: string;
   contentType: MobileIngestContentType;
   caption?: string;
+  highlightTitle: string | null;
 }> {
   const files: BufferedUploadFile[] = [];
   let accountName: string | null = null;
   let uploadedAt: string | undefined;
   let contentType: MobileIngestContentType = 'POST';
   let caption: string | undefined;
+  let highlightTitle: string | null = null;
 
   for await (const part of request.parts()) {
     if (part.type === 'file') {
@@ -192,12 +204,15 @@ async function readMobileIngestForm(request: FastifyRequest): Promise<{
       case 'caption':
         caption = value;
         break;
+      case 'highlightTitle':
+        highlightTitle = normalizeHighlightTitle(value);
+        break;
       default:
         break;
     }
   }
 
-  return { files, accountName, uploadedAt, contentType, caption };
+  return { files, accountName, uploadedAt, contentType, caption, highlightTitle };
 }
 
 async function saveToShared(input: {
@@ -337,6 +352,46 @@ async function saveToSource(input: {
   };
 }
 
+async function saveToHighlight(input: {
+  files: BufferedUploadFile[];
+  accountId: string;
+  highlightTitle: string;
+  postedAt: { date: Date; timestampBase: string };
+}) {
+  const highlightDir = path.join(getSourcePath(input.accountId, input.postedAt.date), input.highlightTitle);
+  await mkdir(highlightDir, { recursive: true });
+
+  const savedFiles: Array<{ filename: string; filepath: string }> = [];
+  const totalFiles = input.files.length;
+
+  for (const [index, entry] of input.files.entries()) {
+    const validation = validateFileType(entry.file.mimetype, entry.buffer.length);
+    if (!validation.valid) {
+      throw new IngestClientError(validation.error || 'Invalid file');
+    }
+
+    const ext = resolveFileExtension(entry.file);
+    const fileSuffix = totalFiles === 1 ? `_UTC${ext}` : `_UTC_${index + 1}${ext}`;
+    const filename = `${input.postedAt.timestampBase}${fileSuffix}`;
+    const filepath = path.join(highlightDir, filename);
+    await writeFile(filepath, entry.buffer);
+    savedFiles.push({ filename, filepath });
+  }
+
+  return {
+    storageTarget: 'HIGHLIGHT' as StorageTarget,
+    accountId: input.accountId,
+    highlightTitle: input.highlightTitle,
+    postId: null,
+    archiveUrl: null,
+    uploadedAt: input.postedAt.date.toISOString(),
+    fileCount: savedFiles.length,
+    uploadBatchId: null,
+    savedFiles,
+    shouldRunIndexer: true
+  };
+}
+
 export async function registerMobileIngestRoutes(app: FastifyInstance): Promise<void> {
   app.post('/api/mobile/instagram-ingest', async (request, reply) => {
     if (!requireMobileIngestAuth(request, reply)) {
@@ -356,6 +411,38 @@ export async function registerMobileIngestRoutes(app: FastifyInstance): Promise<
         })
         : null;
       const postedAt = parsePostedAt(input.uploadedAt);
+
+      if (input.contentType === 'HIGHLIGHT') {
+        if (!input.accountName) {
+          return sendError(reply, 'accountName is required for highlight uploads', 400, 'BAD_REQUEST');
+        }
+
+        if (!existingAccount) {
+          return sendError(reply, 'Account not found for highlight upload', 404, 'NOT_FOUND');
+        }
+
+        if (!input.highlightTitle) {
+          return sendError(reply, 'highlightTitle is required for highlight uploads', 400, 'BAD_REQUEST');
+        }
+
+        if (!postedAt) {
+          return sendError(
+            reply,
+            'uploadedAt must be a valid ISO 8601 datetime for highlight uploads',
+            400,
+            'BAD_REQUEST'
+          );
+        }
+
+        const data = await saveToHighlight({
+          files: input.files,
+          accountId: existingAccount.id,
+          highlightTitle: input.highlightTitle,
+          postedAt
+        });
+
+        return sendSuccess(reply, data);
+      }
 
       if (existingAccount && !postedAt) {
         return sendError(

--- a/frontend/src/components/account/HighlightList.tsx
+++ b/frontend/src/components/account/HighlightList.tsx
@@ -50,7 +50,7 @@ const HighlightList = ({ accountId }: HighlightListProps) => {
                         className="flex flex-col items-center gap-2"
                     >
                         <div className="flex h-16 w-16 items-center justify-center rounded-full border-2 border-white/90 bg-white/95 p-1 shadow-[0_4px_12px_rgba(0,0,0,0.12)] transition hover:border-[#7EC8FF] hover:shadow-[0_0_12px_rgba(126,200,255,0.4)] backdrop-blur-[8px] dark:border-white/20 dark:bg-white/5 dark:shadow-none dark:hover:border-white/40">
-                            {highlight.coverMedia?.url ? (
+                            {highlight.coverUrl ? (
                                 <div className="h-full w-full overflow-hidden rounded-full">
                                     <img
                                         src={highlight.coverUrl}

--- a/frontend/src/components/account/HighlightViewer.tsx
+++ b/frontend/src/components/account/HighlightViewer.tsx
@@ -68,7 +68,7 @@ const HighlightViewer = ({ highlight, accountId, onClose }: HighlightViewerProps
                 <div className="flex h-full items-center justify-center">
                     {currentMedia.mime.startsWith('video') ? (
                         <video
-                            src={`/api/media/${accountId}/${currentMedia.filename}`}
+                            src={currentMedia.url}
                             className="max-h-full max-w-full object-contain"
                             autoPlay
                             controls

--- a/frontend/src/components/account/HighlightViewer.tsx
+++ b/frontend/src/components/account/HighlightViewer.tsx
@@ -68,7 +68,7 @@ const HighlightViewer = ({ highlight, accountId, onClose }: HighlightViewerProps
                 <div className="flex h-full items-center justify-center">
                     {currentMedia.mime.startsWith('video') ? (
                         <video
-                            src={currentMedia.url}
+                            src={currentMedia.rawUrl}
                             className="max-h-full max-w-full object-contain"
                             autoPlay
                             controls

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -119,6 +119,7 @@ export interface HighlightMedia {
   filename: string;
   mime: string;
   orderIndex: number;
+  rawUrl: string;
   url: string;
   thumbnailUrl: string;
 }


### PR DESCRIPTION
## Summary\n- Add HIGHLIGHT as a mobile ingest content type using the existing instagram-ingest endpoint\n- Save highlight uploads under the existing source account highlight folder structure so the indexer can pick them up\n- Fix highlight media URLs and cover rendering so existing highlights show in the web UI\n\n## API\n- POST /api/mobile/instagram-ingest\n- multipart fields: contentType=HIGHLIGHT, accountName, uploadedAt, highlightTitle, files[]\n- Requires an existing account and returns shouldRunIndexer=true\n\n## Verification\n- pnpm --filter @fromistargram/backend lint\n- pnpm --filter @fromistargram/backend test\n- pnpm --filter @fromistargram/frontend build