### PR TITLE
Fix highlight source root indexing

### DIFF
--- a/backend/src/indexer/indexer.test.ts
+++ b/backend/src/indexer/indexer.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildSnapshot } from './indexer.js';
+
+const originalDataRoot = process.env.DATA_ROOT;
+const originalCrawlOutputDir = process.env.CRAWL_OUTPUT_DIR;
+
+let tempDir: string | null = null;
+
+async function createTempDataRoot(): Promise<string> {
+  tempDir = await mkdtemp(path.join(os.tmpdir(), 'fromistargram-indexer-'));
+  return path.join(tempDir, 'data');
+}
+
+describe('buildSnapshot', () => {
+  beforeEach(() => {
+    delete process.env.DATA_ROOT;
+    delete process.env.CRAWL_OUTPUT_DIR;
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+
+    if (originalDataRoot === undefined) {
+      delete process.env.DATA_ROOT;
+    } else {
+      process.env.DATA_ROOT = originalDataRoot;
+    }
+
+    if (originalCrawlOutputDir === undefined) {
+      delete process.env.CRAWL_OUTPUT_DIR;
+    } else {
+      process.env.CRAWL_OUTPUT_DIR = originalCrawlOutputDir;
+    }
+  });
+
+  it('defaults DATA_ROOT to the source directory used by uploads', async () => {
+    const dataRoot = await createTempDataRoot();
+    const highlightDir = path.join(dataRoot, 'source', 'test_account', 'travel');
+    await mkdir(highlightDir, { recursive: true });
+    await writeFile(path.join(highlightDir, '2026-04-27_10-00-00_UTC.jpg'), '');
+
+    process.env.DATA_ROOT = dataRoot;
+
+    const snapshot = await buildSnapshot();
+
+    expect(snapshot.accounts).toHaveLength(1);
+    expect(snapshot.accounts[0]).toMatchObject({
+      id: 'test_account',
+      highlights: [
+        {
+          title: 'travel',
+          media: [
+            {
+              filename: path.join('travel', '2026-04-27_10-00-00_UTC.jpg'),
+              mime: 'image/jpeg',
+              orderIndex: 0
+            }
+          ],
+          coverMedia: null
+        }
+      ]
+    });
+  });
+});

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { promises as fs } from 'fs';
 import { prisma } from '../db/client.js';
 import { clearCache } from '../utils/cache.js';
+import { getSourceRootPath } from '../utils/fileUpload.js';
 import { scanDataRoot } from './fileSystemScanner.js';
 import { IndexerSnapshot } from './types.js';
 
@@ -19,7 +20,7 @@ export type IndexerResult = {
 
 export async function buildSnapshot(options: IndexerOptions = {}): Promise<IndexerSnapshot> {
   const dataRoot =
-    options.dataRoot ?? process.env.CRAWL_OUTPUT_DIR ?? process.env.DATA_ROOT ?? '/root';
+    options.dataRoot ?? process.env.CRAWL_OUTPUT_DIR ?? getSourceRootPath();
   const resolvedRoot = path.resolve(dataRoot);
 
   try {

--- a/backend/src/routes/registerMediaRoutes.ts
+++ b/backend/src/routes/registerMediaRoutes.ts
@@ -6,6 +6,7 @@ import { lookup } from 'mime-types';
 import { z } from 'zod';
 import { sendFileWithRange } from '../utils/range.js';
 import { prisma } from '../db/client.js';
+import { getSourceRootPath } from '../utils/fileUpload.js';
 
 const paramsSchema = z.object({
   account: z.string().min(1),
@@ -90,7 +91,7 @@ async function resolveAccountForFilename(filename: string): Promise<{ accountId:
 }
 
 export async function registerMediaRoutes(app: FastifyInstance): Promise<void> {
-  const dataRoot = process.env.CRAWL_OUTPUT_DIR ?? '/root';
+  const dataRoot = process.env.CRAWL_OUTPUT_DIR ?? getSourceRootPath();
 
   app.get(
     '/api/media/:account/*',

--- a/backend/src/utils/fileUpload.ts
+++ b/backend/src/utils/fileUpload.ts
@@ -53,8 +53,12 @@ export function getUploadPath(date: Date = new Date()): string {
 }
 
 export function getSourcePath(accountId: string, _date: Date = new Date()): string {
+  return path.join(getSourceRootPath(), accountId);
+}
+
+export function getSourceRootPath(): string {
   const dataRoot = process.env.DATA_ROOT ?? '/data';
-  return path.join(dataRoot, 'source', accountId);
+  return path.join(dataRoot, 'source');
 }
 
 export async function saveUploadedFile(


### PR DESCRIPTION
## Summary
- Default the indexer data root to `DATA_ROOT/source` when `CRAWL_OUTPUT_DIR` is not set
- Reuse the same source root for raw `/api/media/:account/*` file serving
- Add a regression test covering `DATA_ROOT`-only highlight indexing

## Root Cause
Mobile highlight uploads are saved under `DATA_ROOT/source/{account}/{highlightTitle}`, but the indexer defaulted to `DATA_ROOT` when `CRAWL_OUTPUT_DIR` was absent.

In the current `docker-compose.yml`, only `DATA_ROOT=/data` is set for the API. That made the indexer scan `/data`, treat `source` as an account folder, and miss actual highlights under `/data/source/{account}/{highlightTitle}`.

## Verification
- `pnpm --filter @fromistargram/backend lint`
- `pnpm --filter @fromistargram/backend test`
- Manual `DATA_ROOT`-only `buildSnapshot()` reproduction