### PR TITLE
Fix uploaded media reconciliation and source roots

### DIFF
--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -2,9 +2,9 @@ import path from 'path';
 import { promises as fs } from 'fs';
 import { prisma } from '../db/client.js';
 import { clearCache } from '../utils/cache.js';
-import { getSourceRootPath } from '../utils/fileUpload.js';
+import { resolveSourceRoot } from '../utils/sourceRoot.js';
 import { scanDataRoot } from './fileSystemScanner.js';
-import { IndexerSnapshot } from './types.js';
+import { IndexedPost, IndexerSnapshot } from './types.js';
 
 export type IndexerOptions = {
   dataRoot?: string;
@@ -12,15 +12,75 @@ export type IndexerOptions = {
 
 export type IndexerResult = {
   accountsCreated: number;
-  postsCreated: number;
-  mediaCreated: number;
+  postsCreated: number; // 신규 + 갱신 반영 건수
+  mediaCreated: number; // 신규 + 갱신 반영 건수
   profilePicsCreated: number;
   tagsCreated: number;
 };
 
+function sortTags(tags: string[]): string[] {
+  return [...tags].sort((a, b) => a.localeCompare(b));
+}
+
+function serializePost(post: IndexedPost): string {
+  return JSON.stringify({
+    postedAt: post.postedAt.toISOString(),
+    caption: post.caption ?? null,
+    hasText: post.hasText,
+    type: post.type,
+    textContent: post.textContent ?? '',
+    tags: sortTags(post.tags),
+    media: post.media
+      .map((item) => ({
+        orderIndex: item.orderIndex,
+        filename: item.filename,
+        mime: item.mime,
+        width: item.width ?? null,
+        height: item.height ?? null,
+        duration: item.duration ?? null
+      }))
+      .sort((a, b) => a.orderIndex - b.orderIndex || a.filename.localeCompare(b.filename))
+  });
+}
+
+function serializeExistingPost(post: {
+  postedAt: Date;
+  caption: string | null;
+  hasText: boolean;
+  type: string;
+  postText?: { content: string } | null;
+  tags: { tag: { name: string } }[];
+  media: {
+    orderIndex: number;
+    filename: string;
+    mime: string;
+    width: number | null;
+    height: number | null;
+    duration: number | null;
+  }[];
+}): string {
+  return JSON.stringify({
+    postedAt: post.postedAt.toISOString(),
+    caption: post.caption ?? null,
+    hasText: post.hasText,
+    type: post.type,
+    textContent: post.postText?.content ?? '',
+    tags: sortTags(post.tags.map((item) => item.tag.name)),
+    media: post.media
+      .map((item) => ({
+        orderIndex: item.orderIndex,
+        filename: item.filename,
+        mime: item.mime,
+        width: item.width ?? null,
+        height: item.height ?? null,
+        duration: item.duration ?? null
+      }))
+      .sort((a, b) => a.orderIndex - b.orderIndex || a.filename.localeCompare(b.filename))
+  });
+}
+
 export async function buildSnapshot(options: IndexerOptions = {}): Promise<IndexerSnapshot> {
-  const dataRoot =
-    options.dataRoot ?? process.env.CRAWL_OUTPUT_DIR ?? getSourceRootPath();
+  const dataRoot = options.dataRoot ?? resolveSourceRoot();
   const resolvedRoot = path.resolve(dataRoot);
 
   try {
@@ -69,28 +129,73 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
       }
     });
 
-    // Account의 기존 Post ID 목록 조회
-    const existingPostIds = await prisma.post.findMany({
+    const snapshotPostIds = new Set(account.posts.map((post) => post.id));
+    const existingPosts = await prisma.post.findMany({
       where: { accountId: account.id },
-      select: { id: true }
-    }).then(posts => posts.map(p => p.id));
+      include: {
+        media: true,
+        postText: true,
+        tags: {
+          include: {
+            tag: true
+          }
+        }
+      }
+    });
 
-    // 기존 Post 및 관련 데이터 삭제 (FK 제약 우회를 위해 관련 데이터 먼저 삭제)
-    if (existingPostIds.length > 0) {
-      await prisma.postText.deleteMany({ where: { postId: { in: existingPostIds } } });
-      await prisma.postTag.deleteMany({ where: { postId: { in: existingPostIds } } });
-      await prisma.media.deleteMany({ where: { postId: { in: existingPostIds } } });
-      await prisma.post.deleteMany({ where: { accountId: account.id } });
+    const existingPostsById = new Map(existingPosts.map((post) => [post.id, post]));
+    const deletedPostIds = existingPosts
+      .filter((post) => !snapshotPostIds.has(post.id))
+      .map((post) => post.id);
+
+    if (deletedPostIds.length > 0) {
+      await prisma.post.deleteMany({ where: { id: { in: deletedPostIds } } });
     }
 
-    // 모든 Post 생성/업데이트
-    for (const post of account.posts) {
-      await (prisma.$transaction as any)(async (tx: any) => {
-        // 기존 Post의 관련 데이터 삭제 (중복 방지)
-        await tx.postText.deleteMany({ where: { postId: post.id } });
-        await tx.postTag.deleteMany({ where: { postId: post.id } });
-        await tx.media.deleteMany({ where: { postId: post.id } });
+    const postsToSync = account.posts.filter((post) => {
+      const existing = existingPostsById.get(post.id);
+      if (!existing) {
+        return true;
+      }
 
+      return serializePost(post) !== serializeExistingPost(existing);
+    });
+
+    const tagNames = new Set<string>();
+    for (const post of postsToSync) {
+      for (const tag of post.tags) {
+        tagNames.add(tag);
+      }
+    }
+
+    let tagNameToId = new Map<string, number>();
+    if (tagNames.size > 0) {
+      const names = [...tagNames];
+      const existingTags = await prisma.tag.findMany({
+        where: { name: { in: names } },
+        select: { id: true, name: true }
+      });
+      const missingTagNames = names.filter(
+        (name) => !existingTags.some((existingTag) => existingTag.name === name)
+      );
+
+      if (missingTagNames.length > 0) {
+        await (prisma.tag as any).createMany({
+          data: missingTagNames.map((name) => ({ name })),
+          skipDuplicates: true
+        });
+        stats.tagsCreated += missingTagNames.length;
+      }
+
+      const resolvedTags = await prisma.tag.findMany({
+        where: { name: { in: names } },
+        select: { id: true, name: true }
+      });
+      tagNameToId = new Map(resolvedTags.map((tag) => [tag.name, tag.id]));
+    }
+
+    for (const post of postsToSync) {
+      await (prisma.$transaction as any)(async (tx: any) => {
         await tx.post.upsert({
           where: { id: post.id },
           create: {
@@ -108,9 +213,14 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
             type: post.type
           }
         });
-        stats.postsCreated += 1;
 
-        // Media 생성
+        await tx.postText.upsert({
+          where: { postId: post.id },
+          create: { postId: post.id, content: post.textContent ?? '' },
+          update: { content: post.textContent ?? '' }
+        });
+
+        await tx.media.deleteMany({ where: { postId: post.id } });
         if (post.media.length > 0) {
           await tx.media.createMany({
             data: post.media.map((media) => ({
@@ -121,47 +231,49 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
               width: media.width,
               height: media.height,
               duration: media.duration
-            })),
-            skipDuplicates: true
+            }))
           });
           stats.mediaCreated += post.media.length;
         }
 
-        // Tag 처리
-        for (const tagName of post.tags) {
-          let tag = await tx.tag.findUnique({ where: { name: tagName } });
-          if (!tag) {
-            tag = await tx.tag.create({ data: { name: tagName } });
-            stats.tagsCreated += 1;
-          }
-
-          await tx.postTag.upsert({
-            where: { postId_tagId: { postId: post.id, tagId: tag.id } },
-            create: { postId: post.id, tagId: tag.id },
-            update: {}
+        await tx.postTag.deleteMany({ where: { postId: post.id } });
+        const tagIds = post.tags
+          .map((tagName) => tagNameToId.get(tagName))
+          .filter((value): value is number => value !== undefined);
+        if (tagIds.length > 0) {
+          await (tx.postTag as any).createMany({
+            data: tagIds.map((tagId) => ({ postId: post.id, tagId })),
+            skipDuplicates: true
           });
         }
-
-        // PostText 생성
-        await tx.postText.upsert({
-          where: { postId: post.id },
-          create: { postId: post.id, content: post.textContent ?? '' },
-          update: { content: post.textContent ?? '' }
-        });
       }, { timeout: 30000 });
+
+      stats.postsCreated += 1;
     }
 
-    await prisma.profilePic.deleteMany({ where: { accountId: account.id } });
-    if (account.profilePictures.length > 0) {
-      const profilePicResult = await prisma.profilePic.createMany({
-        data: account.profilePictures.map((picture) => ({
+    const existingProfilePics = await prisma.profilePic.findMany({
+      where: { accountId: account.id },
+      select: { id: true }
+    });
+    const existingProfilePicIds = new Set(existingProfilePics.map((item) => item.id));
+    const snapshotProfilePicIds = new Set(account.profilePictures.map((item) => item.id));
+    const removedProfilePicIds = [...existingProfilePicIds].filter((id) => !snapshotProfilePicIds.has(id));
+    if (removedProfilePicIds.length > 0) {
+      await prisma.profilePic.deleteMany({ where: { id: { in: removedProfilePicIds } } });
+    }
+
+    const addedProfilePics = account.profilePictures.filter((picture) => !existingProfilePicIds.has(picture.id));
+    if (addedProfilePics.length > 0) {
+      await prisma.profilePic.createMany({
+        data: addedProfilePics.map((picture) => ({
           id: picture.id,
           accountId: picture.accountId,
           takenAt: picture.takenAt,
           filename: picture.filename
-        }))
+        })),
+        skipDuplicates: true
       });
-      stats.profilePicsCreated += profilePicResult.count ?? account.profilePictures.length;
+      stats.profilePicsCreated += addedProfilePics.length;
     }
 
     // Sync Highlights
@@ -210,6 +322,18 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
           data: { coverMediaId: cover.id }
         });
       }
+    }
+
+    const existingHighlights = await prisma.highlight.findMany({
+      where: { accountId: account.id },
+      select: { id: true, title: true }
+    });
+    const snapshotHighlightTitles = new Set(account.highlights.map((highlight) => highlight.title));
+    const removedHighlightIds = existingHighlights
+      .filter((highlight) => !snapshotHighlightTitles.has(highlight.title))
+      .map((highlight) => highlight.id);
+    if (removedHighlightIds.length > 0) {
+      await prisma.highlight.deleteMany({ where: { id: { in: removedHighlightIds } } });
     }
   }
 

--- a/backend/src/routes/registerAdminDatabaseRoutes.ts
+++ b/backend/src/routes/registerAdminDatabaseRoutes.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { fetchDatabaseOverview } from '../services/databaseInspectService.js';
-import { deleteAccount } from '../services/accountsService.js';
+import { createAccount, deleteAccount } from '../services/accountsService.js';
+import { AccountSchema } from './schemas.js';
 import { sendSuccess, sendError } from '../utils/response.js';
 
 const tablePreviewSchema = {
@@ -52,6 +53,55 @@ const errorResponseSchema = {
 } as const;
 
 export async function registerAdminDatabaseRoutes(app: FastifyInstance): Promise<void> {
+  app.post(
+    '/api/admin/db/accounts',
+    {
+      schema: {
+        tags: ['AdminDatabase'],
+        body: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', minLength: 1 }
+          },
+          required: ['id'],
+          additionalProperties: false
+        },
+        response: {
+          201: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: true },
+              data: AccountSchema
+            },
+            required: ['success', 'data'],
+            additionalProperties: false
+          },
+          400: errorResponseSchema,
+          409: errorResponseSchema,
+          500: errorResponseSchema
+        }
+      }
+    },
+    async (request, reply) => {
+      const { id } = request.body as { id: string };
+      try {
+        const account = await createAccount({ id });
+        return sendSuccess(reply, account, 201);
+      } catch (error) {
+        if (error instanceof Error && error.message === 'Account already exists.') {
+          return sendError(reply, error.message, 409, 'ACCOUNT_ALREADY_EXISTS');
+        }
+
+        if (error instanceof Error && error.message.startsWith('Account id')) {
+          return sendError(reply, error.message, 400, 'BAD_REQUEST');
+        }
+
+        request.log.error(error, 'Failed to create account');
+        return sendError(reply, 'Failed to create account');
+      }
+    }
+  );
+
   app.get(
     '/api/admin/db-overview',
     {

--- a/backend/src/routes/registerAdminIndexerRoutes.ts
+++ b/backend/src/routes/registerAdminIndexerRoutes.ts
@@ -1,5 +1,10 @@
 import { FastifyInstance } from 'fastify';
 import { getIndexerStatus, scheduleIndexerRun, triggerIndexerRun } from '../services/indexerService.js';
+import {
+  getUploadedReconcilerStatus,
+  scheduleUploadedReconcile,
+  triggerUploadedReconcile
+} from '../services/uploadedReconcilerService.js';
 import { sendSuccess } from '../utils/response.js';
 
 const indexerStatusSchema = {
@@ -25,6 +30,53 @@ const statusResponseSchema = {
   additionalProperties: false
 } as const;
 
+const uploadedReconcileResultSchema = {
+  type: 'object',
+  properties: {
+    scannedFiles: { type: 'number' },
+    dbRowsScanned: { type: 'number' },
+    missingFileRows: { type: 'number' },
+    orphanFiles: { type: 'number' },
+    orphanFilesDeleted: { type: 'number' },
+    deletedDbRowsPruned: { type: 'number' },
+    sizeRecalculated: { type: 'number' }
+  },
+  required: [
+    'scannedFiles',
+    'dbRowsScanned',
+    'missingFileRows',
+    'orphanFiles',
+    'orphanFilesDeleted',
+    'deletedDbRowsPruned',
+    'sizeRecalculated'
+  ],
+  additionalProperties: false
+} as const;
+
+const uploadedReconcilerStatusSchema = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['idle', 'running', 'success', 'failure'] },
+    lastStartedAt: { type: ['string', 'null'], format: 'date-time' },
+    lastFinishedAt: { type: ['string', 'null'], format: 'date-time' },
+    lastError: { type: ['string', 'null'] },
+    running: { type: 'boolean' },
+    lastResult: { anyOf: [uploadedReconcileResultSchema, { type: 'null' }] }
+  },
+  required: ['status', 'lastStartedAt', 'lastFinishedAt', 'lastError', 'running', 'lastResult'],
+  additionalProperties: false
+} as const;
+
+const uploadedStatusResponseSchema = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean', const: true },
+    data: uploadedReconcilerStatusSchema
+  },
+  required: ['success', 'data'],
+  additionalProperties: false
+} as const;
+
 export async function registerAdminIndexerRoutes(app: FastifyInstance): Promise<void> {
   app.get(
     '/api/admin/indexer',
@@ -38,6 +90,21 @@ export async function registerAdminIndexerRoutes(app: FastifyInstance): Promise<
     },
     async (request, reply) => {
       return sendSuccess(reply, getIndexerStatus());
+    }
+  );
+
+  app.get(
+    '/api/admin/uploaded-reconciler',
+    {
+      schema: {
+        tags: ['AdminIndexer'],
+        response: {
+          200: uploadedStatusResponseSchema
+        }
+      }
+    },
+    async (_request, reply) => {
+      return sendSuccess(reply, getUploadedReconcilerStatus());
     }
   );
 
@@ -57,6 +124,43 @@ export async function registerAdminIndexerRoutes(app: FastifyInstance): Promise<
         await triggerIndexerRun('manual-trigger');
       }
       return sendSuccess(reply, getIndexerStatus(), 202);
+    }
+  );
+
+  app.post(
+    '/api/admin/uploaded-reconciler/run',
+    {
+      schema: {
+        tags: ['AdminIndexer'],
+        body: {
+          type: 'object',
+          properties: {
+            dryRun: { type: 'boolean' },
+            cleanOrphanOlderThanDays: { type: 'number', minimum: 0 },
+            pruneDeletedDbOlderThanDays: { type: 'number', minimum: 0 },
+            recalculateSize: { type: 'boolean' }
+          },
+          additionalProperties: false
+        },
+        response: {
+          202: uploadedStatusResponseSchema
+        }
+      }
+    },
+    async (request, reply) => {
+      const options = (request.body ?? {}) as {
+        dryRun?: boolean;
+        cleanOrphanOlderThanDays?: number;
+        pruneDeletedDbOlderThanDays?: number;
+        recalculateSize?: boolean;
+      };
+
+      scheduleUploadedReconcile('manual-trigger', options);
+      if (process.env.NODE_ENV === 'test') {
+        await triggerUploadedReconcile('manual-trigger', options);
+      }
+
+      return sendSuccess(reply, getUploadedReconcilerStatus(), 202);
     }
   );
 }

--- a/backend/src/routes/registerMediaRoutes.ts
+++ b/backend/src/routes/registerMediaRoutes.ts
@@ -6,7 +6,7 @@ import { lookup } from 'mime-types';
 import { z } from 'zod';
 import { sendFileWithRange } from '../utils/range.js';
 import { prisma } from '../db/client.js';
-import { getSourceRootPath } from '../utils/fileUpload.js';
+import { resolveSourceRoot } from '../utils/sourceRoot.js';
 
 const paramsSchema = z.object({
   account: z.string().min(1),
@@ -91,7 +91,7 @@ async function resolveAccountForFilename(filename: string): Promise<{ accountId:
 }
 
 export async function registerMediaRoutes(app: FastifyInstance): Promise<void> {
-  const dataRoot = process.env.CRAWL_OUTPUT_DIR ?? getSourceRootPath();
+  const dataRoot = resolveSourceRoot();
 
   app.get(
     '/api/media/:account/*',

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -107,7 +107,7 @@ export async function buildServer(options: BuildServerOptions = {}): Promise<Fas
       ? Number(process.hrtime.bigint() - metricsStart) / 1_000_000
       : reply.getResponseTime();
 
-    const routePath = request.routerPath ?? request.url;
+    const routePath = request.routeOptions.url ?? request.url;
 
     request.log.info(
       {

--- a/backend/src/services/accountsService.ts
+++ b/backend/src/services/accountsService.ts
@@ -1,6 +1,9 @@
+import { mkdir } from 'fs/promises';
+import path from 'path';
 import { prisma } from '../db/client.js';
-import { cacheKey, cacheTtlSeconds, withCache } from '../utils/cache.js';
+import { cacheKey, cacheTtlSeconds, clearCache, withCache } from '../utils/cache.js';
 import { buildImagorUrl } from '../utils/imagor.js';
+import { resolveSourceAccountPath, resolveSourceRoot } from '../utils/sourceRoot.js';
 
 export type AccountSummary = {
   id: string;
@@ -29,6 +32,45 @@ export type Account = AccountSummary & {
     takenAt: string;
   }[];
 };
+
+export type CreateAccountInput = {
+  id: string;
+};
+
+const ACCOUNT_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+function normalizeAccountId(id: string): string {
+  return id.trim().replace(/^@+/, '');
+}
+
+function assertValidAccountId(id: string): void {
+  if (!id || id.length > 128) {
+    throw new Error('Account id must be between 1 and 128 characters.');
+  }
+
+  if (
+    !ACCOUNT_ID_PATTERN.test(id) ||
+    id.includes('..') ||
+    id.includes('/') ||
+    id.includes('\\') ||
+    path.isAbsolute(id)
+  ) {
+    throw new Error('Account id can only contain letters, numbers, dots, underscores, and hyphens.');
+  }
+}
+
+function resolveSafeAccountPath(accountId: string): string {
+  const sourceRoot = resolveSourceRoot();
+  const accountPath = resolveSourceAccountPath(accountId);
+  const isInsideRoot =
+    accountPath === sourceRoot || accountPath.startsWith(`${sourceRoot}${path.sep}`);
+
+  if (!isInsideRoot) {
+    throw new Error('Account path escapes source root.');
+  }
+
+  return accountPath;
+}
 
 export async function getAccount(id: string): Promise<Account | null> {
   const key = cacheKey(['accounts', id]);
@@ -152,6 +194,37 @@ export async function listAccounts(): Promise<Account[]> {
   );
 }
 
+export async function createAccount(input: CreateAccountInput): Promise<Account> {
+  const id = normalizeAccountId(input.id);
+  assertValidAccountId(id);
+
+  const existing = await prisma.account.findUnique({ where: { id } });
+  if (existing) {
+    throw new Error('Account already exists.');
+  }
+
+  await mkdir(resolveSafeAccountPath(id), { recursive: true });
+
+  await prisma.account.upsert({
+    where: { id },
+    create: {
+      id,
+      lastIndexedAt: null,
+      latestProfilePicUrl: null
+    },
+    update: {}
+  });
+
+  await clearCache();
+
+  const account = await getAccount(id);
+  if (!account) {
+    throw new Error('Failed to load created account.');
+  }
+
+  return account;
+}
+
 export async function deleteAccount(id: string): Promise<boolean> {
   const account = await prisma.account.findUnique({ where: { id } });
   if (!account) {
@@ -159,5 +232,6 @@ export async function deleteAccount(id: string): Promise<boolean> {
   }
 
   await prisma.account.delete({ where: { id } });
+  await clearCache();
   return true;
 }

--- a/backend/src/services/databaseInspectService.ts
+++ b/backend/src/services/databaseInspectService.ts
@@ -25,6 +25,7 @@ export async function fetchDatabaseOverview(): Promise<DatabaseOverview> {
     ] = await Promise.all([
       client.account.findMany({
         orderBy: { updatedAt: 'desc' },
+        take: 5,
         select: {
           id: true,
           lastIndexedAt: true,

--- a/backend/src/services/uploadedReconcilerService.ts
+++ b/backend/src/services/uploadedReconcilerService.ts
@@ -1,0 +1,245 @@
+import { readdir, stat, unlink } from 'fs/promises';
+import path from 'path';
+import { prisma } from '../db/client.js';
+import { resolveUploadedRoot } from '../utils/sourceRoot.js';
+
+export type UploadedReconcilerStatus = 'idle' | 'running' | 'success' | 'failure';
+
+export type UploadedReconcileOptions = {
+  dryRun?: boolean;
+  cleanOrphanOlderThanDays?: number;
+  pruneDeletedDbOlderThanDays?: number;
+  recalculateSize?: boolean;
+};
+
+export type UploadedReconcileResult = {
+  scannedFiles: number;
+  dbRowsScanned: number;
+  missingFileRows: number;
+  orphanFiles: number;
+  orphanFilesDeleted: number;
+  deletedDbRowsPruned: number;
+  sizeRecalculated: number;
+};
+
+type UploadedReconcilerState = {
+  status: UploadedReconcilerStatus;
+  running: boolean;
+  lastStartedAt: Date | null;
+  lastFinishedAt: Date | null;
+  lastError: string | null;
+  lastResult: UploadedReconcileResult | null;
+};
+
+let currentRun: Promise<void> | null = null;
+let lastState: UploadedReconcilerState = {
+  status: 'idle',
+  running: false,
+  lastStartedAt: null,
+  lastFinishedAt: null,
+  lastError: null,
+  lastResult: null
+};
+
+async function collectUploadedFiles(root: string): Promise<Map<string, { absolutePath: string; mtimeMs: number }>> {
+  const files = new Map<string, { absolutePath: string; mtimeMs: number }>();
+  let dayDirs: { isDirectory(): boolean; isFile(): boolean; name: string | Buffer }[] = [];
+
+  try {
+    dayDirs = await readdir(root, { withFileTypes: true });
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code === 'ENOENT') {
+      return files;
+    }
+    throw error;
+  }
+
+  for (const dayDir of dayDirs) {
+    if (!dayDir.isDirectory()) {
+      continue;
+    }
+
+    const dayDirName = String(dayDir.name);
+    const dayDirPath = path.join(root, dayDirName);
+    const dayFiles = await readdir(dayDirPath, { withFileTypes: true });
+
+    for (const dayFile of dayFiles) {
+      if (!dayFile.isFile()) {
+        continue;
+      }
+
+      const dayFileName = String(dayFile.name);
+      const relativePath = path.posix.join(dayDirName, dayFileName);
+      const absolutePath = path.join(dayDirPath, dayFileName);
+      const fileStats = await stat(absolutePath);
+      files.set(relativePath, { absolutePath, mtimeMs: fileStats.mtimeMs });
+    }
+  }
+
+  return files;
+}
+
+function getUploadRelativePath(uploadedAt: Date, filename: string): string {
+  const yyyy = uploadedAt.getUTCFullYear();
+  const mm = String(uploadedAt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(uploadedAt.getUTCDate()).padStart(2, '0');
+  return path.posix.join(`${yyyy}${mm}${dd}`, filename);
+}
+
+async function runUploadedReconcile(options: UploadedReconcileOptions = {}): Promise<UploadedReconcileResult> {
+  const uploadedRoot = resolveUploadedRoot();
+  const dryRun = options.dryRun ?? false;
+  const cleanOrphanOlderThanDays = options.cleanOrphanOlderThanDays ?? 7;
+  const pruneDeletedDbOlderThanDays = options.pruneDeletedDbOlderThanDays ?? 30;
+  const recalculateSize = options.recalculateSize ?? true;
+
+  const nowMs = Date.now();
+  const orphanCutoffMs = nowMs - cleanOrphanOlderThanDays * 24 * 60 * 60 * 1000;
+  const deletedDbCutoff = new Date(nowMs - pruneDeletedDbOlderThanDays * 24 * 60 * 60 * 1000);
+
+  const [uploadedFiles, dbRows] = await Promise.all([
+    collectUploadedFiles(uploadedRoot),
+    prisma.sharedMedia.findMany({
+      select: {
+        id: true,
+        filename: true,
+        uploadedAt: true,
+        isDeleted: true,
+        size: true
+      }
+    })
+  ]);
+
+  const dbRelativePaths = new Map<string, { id: string; isDeleted: boolean; size: number }>();
+  for (const row of dbRows) {
+    dbRelativePaths.set(getUploadRelativePath(row.uploadedAt, row.filename), {
+      id: row.id,
+      isDeleted: row.isDeleted,
+      size: row.size
+    });
+  }
+
+  let missingFileRows = 0;
+  let sizeRecalculated = 0;
+  for (const [relativePath, row] of dbRelativePaths.entries()) {
+    const fileInfo = uploadedFiles.get(relativePath);
+    if (!fileInfo) {
+      missingFileRows += 1;
+      continue;
+    }
+
+    if (recalculateSize) {
+      const fileStats = await stat(fileInfo.absolutePath);
+      if (fileStats.size !== row.size && !dryRun) {
+        await prisma.sharedMedia.update({ where: { id: row.id }, data: { size: Number(fileStats.size) } });
+        sizeRecalculated += 1;
+      }
+    }
+  }
+
+  const orphanCandidates = [...uploadedFiles.entries()].filter(([relativePath]) => !dbRelativePaths.has(relativePath));
+
+  let orphanFilesDeleted = 0;
+  if (!dryRun) {
+    for (const [, file] of orphanCandidates) {
+      if (file.mtimeMs >= orphanCutoffMs) {
+        continue;
+      }
+
+      await unlink(file.absolutePath);
+      orphanFilesDeleted += 1;
+    }
+  }
+
+  let deletedDbRowsPruned = 0;
+  if (!dryRun) {
+    const result = await prisma.sharedMedia.deleteMany({
+      where: {
+        isDeleted: true,
+        uploadedAt: { lt: deletedDbCutoff }
+      }
+    });
+
+    deletedDbRowsPruned = result.count;
+  }
+
+  return {
+    scannedFiles: uploadedFiles.size,
+    dbRowsScanned: dbRows.length,
+    missingFileRows,
+    orphanFiles: orphanCandidates.length,
+    orphanFilesDeleted,
+    deletedDbRowsPruned,
+    sizeRecalculated
+  };
+}
+
+function startRun(reason?: string, options: UploadedReconcileOptions = {}): void {
+  lastState = {
+    ...lastState,
+    status: 'running',
+    running: true,
+    lastStartedAt: new Date(),
+    lastFinishedAt: null,
+    lastError: null,
+    lastResult: null
+  };
+
+  currentRun = runUploadedReconcile(options)
+    .then((result) => {
+      console.info('Uploaded reconciler run succeeded', { reason, ...result });
+      lastState = {
+        ...lastState,
+        status: 'success',
+        running: false,
+        lastFinishedAt: new Date(),
+        lastError: null,
+        lastResult: result
+      };
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : 'Unknown reconcile error';
+      console.error('Uploaded reconciler run failed', { reason, error });
+      lastState = {
+        ...lastState,
+        status: 'failure',
+        running: false,
+        lastFinishedAt: new Date(),
+        lastError: message,
+        lastResult: null
+      };
+    })
+    .finally(() => {
+      currentRun = null;
+    });
+}
+
+export function scheduleUploadedReconcile(reason?: string, options: UploadedReconcileOptions = {}): void {
+  if (currentRun) {
+    return;
+  }
+
+  startRun(reason, options);
+}
+
+export async function triggerUploadedReconcile(reason?: string, options: UploadedReconcileOptions = {}): Promise<void> {
+  if (!currentRun) {
+    scheduleUploadedReconcile(reason, options);
+  }
+
+  if (currentRun) {
+    await currentRun;
+  }
+}
+
+export function getUploadedReconcilerStatus() {
+  return {
+    status: currentRun ? 'running' : lastState.status,
+    running: Boolean(currentRun),
+    lastStartedAt: lastState.lastStartedAt ? lastState.lastStartedAt.toISOString() : null,
+    lastFinishedAt: lastState.lastFinishedAt ? lastState.lastFinishedAt.toISOString() : null,
+    lastError: lastState.lastError,
+    lastResult: lastState.lastResult
+  };
+}

--- a/backend/src/utils/fileUpload.ts
+++ b/backend/src/utils/fileUpload.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
 import { MultipartFile } from '@fastify/multipart';
 import { formatDateToYYYYMMDD } from './dateFormat.js';
+import { resolveSourceAccountPath } from './sourceRoot.js';
 
 const MAX_IMAGE_SIZE = 30 * 1024 * 1024; // 30MB
 const MAX_VIDEO_SIZE = 200 * 1024 * 1024; // 50MB
@@ -51,12 +52,7 @@ export function getUploadPath(date: Date = new Date()): string {
 }
 
 export function getSourcePath(accountId: string, _date: Date = new Date()): string {
-  return path.join(getSourceRootPath(), accountId);
-}
-
-export function getSourceRootPath(): string {
-  const dataRoot = process.env.DATA_ROOT ?? '/data';
-  return path.join(dataRoot, 'source');
+  return resolveSourceAccountPath(accountId);
 }
 
 export async function saveUploadedFile(

--- a/backend/src/utils/sourceRoot.ts
+++ b/backend/src/utils/sourceRoot.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+
+export function resolveSourceRoot(): string {
+  const crawlOutputRoot = process.env.CRAWL_OUTPUT_DIR?.trim();
+  if (crawlOutputRoot) {
+    return path.resolve(crawlOutputRoot);
+  }
+
+  const dataRoot = process.env.DATA_ROOT?.trim();
+  if (dataRoot) {
+    return path.resolve(dataRoot, 'source');
+  }
+
+  return path.resolve('/root');
+}
+
+export function resolveSourceAccountPath(accountId: string): string {
+  const sourceRoot = resolveSourceRoot();
+  return path.resolve(sourceRoot, accountId);
+}
+
+export function resolveUploadedRoot(): string {
+  const dataRoot = process.env.DATA_ROOT?.trim();
+  if (dataRoot) {
+    return path.resolve(dataRoot, 'uploaded');
+  }
+
+  return path.resolve('/data/uploaded');
+}

--- a/frontend/src/lib/api/admin/consts.ts
+++ b/frontend/src/lib/api/admin/consts.ts
@@ -2,6 +2,7 @@ export const ADMIN_KEY = 'admin';
 
 export const ADMIN_FEED_STATISTICS_PATH = '/admin/feed-statistics';
 export const ADMIN_INDEXER_PATH = '/admin/indexer';
+export const ADMIN_UPLOADED_RECONCILER_PATH = '/admin/uploaded-reconciler';
 export const ADMIN_DB_OVERVIEW_PATH = '/admin/db-overview';
 export const ADMIN_SHARED_MEDIA_PATH = '/admin/shared';
 export const ADMIN_UPLOADS_PATH = '/admin/manual-upload';

--- a/frontend/src/lib/api/admin/database.ts
+++ b/frontend/src/lib/api/admin/database.ts
@@ -1,9 +1,13 @@
 import { fetchApi } from '../../queryClient';
 import { ADMIN_DB_OVERVIEW_PATH } from './consts';
 import { type ApiResponse, type DatabaseOverview } from './types';
+import { type AccountResponse } from '../types';
 
 export const fetchDatabaseOverview = () =>
   fetchApi.get<ApiResponse<DatabaseOverview>>(ADMIN_DB_OVERVIEW_PATH).then((res) => res.data);
+
+export const createDatabaseAccount = (id: string) =>
+  fetchApi.post<AccountResponse>('/admin/db/accounts', { id }).then((res) => res.data);
 
 export const deleteDatabaseAccount = (id: string) =>
   fetchApi.delete(`/admin/db/accounts/${id}`);

--- a/frontend/src/lib/api/admin/indexer.ts
+++ b/frontend/src/lib/api/admin/indexer.ts
@@ -1,9 +1,27 @@
 import { fetchApi } from '../../queryClient';
-import { ADMIN_INDEXER_PATH } from './consts';
-import type { ApiResponse, IndexerStatus } from './types';
+import { ADMIN_INDEXER_PATH, ADMIN_UPLOADED_RECONCILER_PATH } from './consts';
+import type { ApiResponse, IndexerStatus, UploadedReconcilerStatus } from './types';
 
 export const fetchIndexerStatus = () =>
   fetchApi.get<ApiResponse<IndexerStatus>>(ADMIN_INDEXER_PATH).then((res) => res.data);
 
 export const requestIndexerRun = () =>
   fetchApi.post<ApiResponse<IndexerStatus>>(`${ADMIN_INDEXER_PATH}/run`).then((res) => res.data);
+
+export const fetchUploadedReconcilerStatus = () =>
+  fetchApi
+    .get<ApiResponse<UploadedReconcilerStatus>>(ADMIN_UPLOADED_RECONCILER_PATH)
+    .then((res) => res.data);
+
+export const requestUploadedReconcilerRun = (options?: {
+  dryRun?: boolean;
+  cleanOrphanOlderThanDays?: number;
+  pruneDeletedDbOlderThanDays?: number;
+  recalculateSize?: boolean;
+}) =>
+  fetchApi
+    .post<ApiResponse<UploadedReconcilerStatus>>(
+      `${ADMIN_UPLOADED_RECONCILER_PATH}/run`,
+      options ?? {}
+    )
+    .then((res) => res.data);

--- a/frontend/src/lib/api/admin/types.ts
+++ b/frontend/src/lib/api/admin/types.ts
@@ -18,6 +18,20 @@ export interface IndexerStatus {
   lastError: string | null;
 }
 
+export interface UploadedReconcilerResult {
+  scannedFiles: number;
+  dbRowsScanned: number;
+  missingFileRows: number;
+  orphanFiles: number;
+  orphanFilesDeleted: number;
+  deletedDbRowsPruned: number;
+  sizeRecalculated: number;
+}
+
+export interface UploadedReconcilerStatus extends IndexerStatus {
+  lastResult: UploadedReconcilerResult | null;
+}
+
 export interface TablePreview {
   key: string;
   label: string;

--- a/frontend/src/routes/admin/AdminDatabasePage.tsx
+++ b/frontend/src/routes/admin/AdminDatabasePage.tsx
@@ -1,8 +1,13 @@
-import { useMemo } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import AdminSectionCard from '../../components/admin/AdminSectionCard';
+import { CLIENT_KEY } from '../../lib/api/client';
 import { ADMIN_KEY } from '../../lib/api/admin/consts';
-import { deleteDatabaseAccount, fetchDatabaseOverview } from '../../lib/api/admin/database';
+import {
+  createDatabaseAccount,
+  deleteDatabaseAccount,
+  fetchDatabaseOverview
+} from '../../lib/api/admin/database';
 import type { TablePreview } from '../../lib/api/admin/types';
 
 const formatValue = (value: unknown) => {
@@ -113,6 +118,102 @@ const TablePreviewCard = ({ table }: { table: TablePreview }) => {
   );
 };
 
+const getMutationErrorMessage = (error: unknown, fallback: string) => {
+  if (typeof error === 'object' && error !== null && 'response' in error) {
+    const data = (error as { response?: { data?: { error?: { message?: string } } } }).response
+      ?.data;
+    if (data?.error?.message) {
+      return data.error.message;
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+const AccountCreateCard = () => {
+  const queryClient = useQueryClient();
+  const [accountId, setAccountId] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSuccess, setFormSuccess] = useState<string | null>(null);
+
+  const createAccountMutation = useMutation({
+    mutationFn: createDatabaseAccount,
+    onSuccess: (response) => {
+      setAccountId('');
+      setFormError(null);
+      setFormSuccess(`${response.data.id} 계정을 추가했습니다.`);
+      void queryClient.invalidateQueries({ queryKey: [ADMIN_KEY, 'database', 'overview'] });
+      void queryClient.invalidateQueries({ queryKey: [ADMIN_KEY, 'accounts'] });
+      void queryClient.invalidateQueries({ queryKey: [ADMIN_KEY, 'statistics'] });
+      void queryClient.invalidateQueries({ queryKey: [CLIENT_KEY, 'accounts'] });
+    },
+    onError: (error) => {
+      setFormSuccess(null);
+      setFormError(getMutationErrorMessage(error, '계정 추가에 실패했습니다.'));
+    }
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+    setFormSuccess(null);
+
+    const trimmed = accountId.trim();
+    if (!trimmed) {
+      setFormError('계정 ID를 입력해 주세요.');
+      return;
+    }
+
+    createAccountMutation.mutate(trimmed);
+  };
+
+  return (
+    <AdminSectionCard
+      title="계정 추가"
+      description="수동 업로드와 인덱서가 사용할 계정을 미리 등록합니다."
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label className="flex flex-col gap-2 text-sm text-slate-300">
+          계정 ID
+          <input
+            type="text"
+            value={accountId}
+            onChange={(event) => setAccountId(event.target.value)}
+            placeholder="fromis_9"
+            className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100 focus:border-brand-400 focus:outline-none"
+          />
+        </label>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            disabled={createAccountMutation.isPending}
+            className="rounded bg-brand-600 px-4 py-2 text-sm text-white hover:bg-brand-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {createAccountMutation.isPending ? '추가 중...' : '계정 추가'}
+          </button>
+          <span className="text-xs text-slate-400">
+            영문, 숫자, 점, 밑줄, 하이픈을 사용할 수 있습니다.
+          </span>
+        </div>
+        {formError && (
+          <div className="rounded border border-red-500/60 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+            {formError}
+          </div>
+        )}
+        {formSuccess && (
+          <div className="rounded border border-emerald-500/60 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200">
+            {formSuccess}
+          </div>
+        )}
+      </form>
+    </AdminSectionCard>
+  );
+};
+
 const AdminDatabasePage = () => {
   const { data, isPending, isError } = useQuery({
     queryKey: [ADMIN_KEY, 'database', 'overview'],
@@ -137,6 +238,8 @@ const AdminDatabasePage = () => {
           총 {data.tables.length}개 테이블의 상태를 확인할 수 있습니다.
         </p>
       </AdminSectionCard>
+
+      <AccountCreateCard />
 
       {data.tables.map((table) => (
         <TablePreviewCard key={table.key} table={table} />

--- a/frontend/src/routes/admin/AdminUploadsPage.tsx
+++ b/frontend/src/routes/admin/AdminUploadsPage.tsx
@@ -3,7 +3,12 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tansta
 import AdminSectionCard from '../../components/admin/AdminSectionCard';
 import { ADMIN_KEY } from '../../lib/api/admin/consts';
 import { listAccount } from '../../lib/api/client';
-import { fetchIndexerStatus, requestIndexerRun } from '../../lib/api/admin/indexer';
+import {
+  fetchIndexerStatus,
+  fetchUploadedReconcilerStatus,
+  requestIndexerRun,
+  requestUploadedReconcilerRun
+} from '../../lib/api/admin/indexer';
 import { deleteSharedMedia, listSharedMedia, updateSharedMedia } from '../../lib/api/admin/sharedMedia';
 import { uploadAdminMedia } from '../../lib/api/admin/uploads';
 import type { AdminSharedMedia } from '../../lib/api/admin/types';
@@ -49,6 +54,11 @@ const AdminUploadsPage = () => {
     queryFn: () => fetchIndexerStatus().then((res) => res.data)
   });
 
+  const { data: uploadedReconcilerStatus } = useQuery({
+    queryKey: [ADMIN_KEY, 'uploaded-reconciler'],
+    queryFn: () => fetchUploadedReconcilerStatus().then((res) => res.data)
+  });
+
   const { mutate: runIndexerMutate, isPending: isIndexerRunPending } = useMutation({
     mutationKey: [ADMIN_KEY, 'indexer', 'run'],
     mutationFn: () => requestIndexerRun().then((res) => res.data),
@@ -57,6 +67,16 @@ const AdminUploadsPage = () => {
       void queryClient.invalidateQueries({ queryKey: [ADMIN_KEY, 'shared-media'] });
     }
   });
+
+  const { mutate: runUploadedReconcilerMutate, isPending: isUploadedReconcilerRunPending } =
+    useMutation({
+      mutationKey: [ADMIN_KEY, 'uploaded-reconciler', 'run'],
+      mutationFn: () => requestUploadedReconcilerRun({ dryRun: false }).then((res) => res.data),
+      onSuccess: () => {
+        void queryClient.invalidateQueries({ queryKey: [ADMIN_KEY, 'uploaded-reconciler'] });
+        void queryClient.invalidateQueries({ queryKey: [ADMIN_KEY, 'shared-media'] });
+      }
+    });
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
     useInfiniteQuery({
@@ -157,8 +177,8 @@ const AdminUploadsPage = () => {
   return (
     <div className="space-y-6">
       <AdminSectionCard
-        title="인덱서"
-        description="업로드된 미디어를 DB에 반영하기 위해 인덱서를 실행합니다."
+        title="Source 인덱서"
+        description="/data/source를 스캔해 계정/게시물/미디어/하이라이트를 동기화합니다."
         actions={
           <button
             type="button"
@@ -190,6 +210,52 @@ const AdminUploadsPage = () => {
             <span className="text-xs uppercase tracking-wide text-slate-400">오류</span>
             <p className="mt-1 text-slate-100">
               {indexerStatus?.lastError ?? '없음'}
+            </p>
+          </div>
+        </div>
+      </AdminSectionCard>
+      <AdminSectionCard
+        title="Uploaded Reconciler"
+        description="/data/uploaded와 SharedMedia 정합성을 점검하고 orphan/오래된 삭제 항목을 정리합니다."
+        actions={
+          <button
+            type="button"
+            onClick={() => runUploadedReconcilerMutate()}
+            className="rounded bg-brand-500/80 px-3 py-1 text-xs font-semibold text-slate-950 transition hover:bg-brand-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+            disabled={isUploadedReconcilerRunPending || uploadedReconcilerStatus?.running}
+          >
+            Reconciler 실행
+          </button>
+        }
+      >
+        <div className="grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
+          <div>
+            <span className="text-xs uppercase tracking-wide text-slate-400">상태</span>
+            <p className="mt-1 font-semibold text-slate-100">
+              {uploadedReconcilerStatus?.status ?? '알 수 없음'}
+              {uploadedReconcilerStatus?.running ? ' (실행 중)' : ''}
+            </p>
+          </div>
+          <div>
+            <span className="text-xs uppercase tracking-wide text-slate-400">최근 실행</span>
+            <p className="mt-1 text-slate-100">
+              {uploadedReconcilerStatus?.lastFinishedAt
+                ? new Date(uploadedReconcilerStatus.lastFinishedAt).toLocaleString()
+                : '기록 없음'}
+            </p>
+          </div>
+          <div className="sm:col-span-2">
+            <span className="text-xs uppercase tracking-wide text-slate-400">결과</span>
+            <p className="mt-1 text-slate-100">
+              {uploadedReconcilerStatus?.lastResult
+                ? `missing: ${uploadedReconcilerStatus.lastResult.missingFileRows}, orphan: ${uploadedReconcilerStatus.lastResult.orphanFiles}, orphan deleted: ${uploadedReconcilerStatus.lastResult.orphanFilesDeleted}`
+                : '기록 없음'}
+            </p>
+          </div>
+          <div className="sm:col-span-2">
+            <span className="text-xs uppercase tracking-wide text-slate-400">오류</span>
+            <p className="mt-1 text-slate-100">
+              {uploadedReconcilerStatus?.lastError ?? '없음'}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add shared source/upload root resolution for crawler, media serving, and upload paths
- add uploaded media reconciler APIs and admin UI controls/status
- keep indexer/database admin data in sync and replace deprecated Fastify routerPath logging

## Verification
- pnpm -r lint
- pnpm --filter @fromistargram/backend test
- pnpm -r build
- git diff --check

Note: Vite build still reports baseline-browser-mapping data is over two months old; build succeeds.