### PR TITLE
Address uploaded reconciler review comments

### DIFF
--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -14,7 +14,7 @@ export type IndexerResult = {
   accountsCreated: number;
   postsCreated: number; // 신규 + 갱신 반영 건수
   mediaCreated: number; // 신규 + 갱신 반영 건수
-  profilePicsCreated: number;
+  profilePicsSynced: number; // 신규 + 갱신 반영 건수
   tagsCreated: number;
 };
 
@@ -102,7 +102,7 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
     accountsCreated: 0,
     postsCreated: 0,
     mediaCreated: 0,
-    profilePicsCreated: 0,
+    profilePicsSynced: 0,
     tagsCreated: 0
   };
 
@@ -257,13 +257,14 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
     });
     const existingProfilePicsById = new Map(existingProfilePics.map((item) => [item.id, item]));
     const existingProfilePicIds = new Set(existingProfilePicsById.keys());
-    const snapshotProfilePicIds = new Set(account.profilePictures.map((item) => item.id));
+    const snapshotProfilePicsById = new Map(account.profilePictures.map((item) => [item.id, item]));
+    const snapshotProfilePicIds = new Set(snapshotProfilePicsById.keys());
     const removedProfilePicIds = [...existingProfilePicIds].filter((id) => !snapshotProfilePicIds.has(id));
     if (removedProfilePicIds.length > 0) {
       await prisma.profilePic.deleteMany({ where: { id: { in: removedProfilePicIds } } });
     }
 
-    for (const picture of account.profilePictures) {
+    for (const picture of snapshotProfilePicsById.values()) {
       const existingPicture = existingProfilePicsById.get(picture.id);
       if (!existingPicture) {
         await prisma.profilePic.create({
@@ -274,7 +275,7 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
             filename: picture.filename
           }
         });
-        stats.profilePicsCreated += 1;
+        stats.profilePicsSynced += 1;
         continue;
       }
 
@@ -286,7 +287,7 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
             filename: picture.filename
           }
         });
-        stats.profilePicsCreated += 1;
+        stats.profilePicsSynced += 1;
       }
     }
 

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -180,7 +180,7 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
       );
 
       if (missingTagNames.length > 0) {
-        await (prisma.tag as any).createMany({
+        await prisma.tag.createMany({
           data: missingTagNames.map((name) => ({ name })),
           skipDuplicates: true
         });
@@ -195,7 +195,7 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
     }
 
     for (const post of postsToSync) {
-      await (prisma.$transaction as any)(async (tx: any) => {
+      await prisma.$transaction(async (tx) => {
         await tx.post.upsert({
           where: { id: post.id },
           create: {
@@ -241,7 +241,7 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
           .map((tagName) => tagNameToId.get(tagName))
           .filter((value): value is number => value !== undefined);
         if (tagIds.length > 0) {
-          await (tx.postTag as any).createMany({
+          await tx.postTag.createMany({
             data: tagIds.map((tagId) => ({ postId: post.id, tagId })),
             skipDuplicates: true
           });
@@ -253,27 +253,41 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
 
     const existingProfilePics = await prisma.profilePic.findMany({
       where: { accountId: account.id },
-      select: { id: true }
+      select: { id: true, takenAt: true, filename: true }
     });
-    const existingProfilePicIds = new Set(existingProfilePics.map((item) => item.id));
+    const existingProfilePicsById = new Map(existingProfilePics.map((item) => [item.id, item]));
+    const existingProfilePicIds = new Set(existingProfilePicsById.keys());
     const snapshotProfilePicIds = new Set(account.profilePictures.map((item) => item.id));
     const removedProfilePicIds = [...existingProfilePicIds].filter((id) => !snapshotProfilePicIds.has(id));
     if (removedProfilePicIds.length > 0) {
       await prisma.profilePic.deleteMany({ where: { id: { in: removedProfilePicIds } } });
     }
 
-    const addedProfilePics = account.profilePictures.filter((picture) => !existingProfilePicIds.has(picture.id));
-    if (addedProfilePics.length > 0) {
-      await prisma.profilePic.createMany({
-        data: addedProfilePics.map((picture) => ({
-          id: picture.id,
-          accountId: picture.accountId,
-          takenAt: picture.takenAt,
-          filename: picture.filename
-        })),
-        skipDuplicates: true
-      });
-      stats.profilePicsCreated += addedProfilePics.length;
+    for (const picture of account.profilePictures) {
+      const existingPicture = existingProfilePicsById.get(picture.id);
+      if (!existingPicture) {
+        await prisma.profilePic.create({
+          data: {
+            id: picture.id,
+            accountId: picture.accountId,
+            takenAt: picture.takenAt,
+            filename: picture.filename
+          }
+        });
+        stats.profilePicsCreated += 1;
+        continue;
+      }
+
+      if (existingPicture.filename !== picture.filename || existingPicture.takenAt.getTime() !== picture.takenAt.getTime()) {
+        await prisma.profilePic.update({
+          where: { id: picture.id },
+          data: {
+            takenAt: picture.takenAt,
+            filename: picture.filename
+          }
+        });
+        stats.profilePicsCreated += 1;
+      }
     }
 
     // Sync Highlights

--- a/backend/src/indexer/syncSnapshotToDatabase.test.ts
+++ b/backend/src/indexer/syncSnapshotToDatabase.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const prismaMock = {
+  account: {
+    findUnique: vi.fn(),
+    upsert: vi.fn()
+  },
+  post: {
+    findMany: vi.fn(),
+    deleteMany: vi.fn()
+  },
+  profilePic: {
+    findMany: vi.fn(),
+    deleteMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn()
+  },
+  highlight: {
+    findMany: vi.fn(),
+    deleteMany: vi.fn()
+  }
+};
+
+const clearCacheMock = vi.fn();
+
+vi.mock('../db/client.js', () => ({
+  prisma: prismaMock
+}));
+
+vi.mock('../utils/cache.js', () => ({
+  clearCache: clearCacheMock
+}));
+
+describe('syncSnapshotToDatabase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prismaMock.account.findUnique.mockResolvedValue({ id: 'account_1' });
+    prismaMock.account.upsert.mockResolvedValue({});
+    prismaMock.post.findMany.mockResolvedValue([]);
+    prismaMock.post.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.profilePic.findMany.mockResolvedValue([]);
+    prismaMock.profilePic.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.profilePic.create.mockResolvedValue({});
+    prismaMock.profilePic.update.mockResolvedValue({});
+    prismaMock.highlight.findMany.mockResolvedValue([]);
+    prismaMock.highlight.deleteMany.mockResolvedValue({ count: 0 });
+    clearCacheMock.mockResolvedValue(undefined);
+  });
+
+  it('deduplicates profile picture ids before creating rows', async () => {
+    const { syncSnapshotToDatabase } = await import('./indexer.js');
+    const takenAt = new Date('2026-04-29T00:00:00.000Z');
+
+    const result = await syncSnapshotToDatabase({
+      accounts: [
+        {
+          id: 'account_1',
+          profilePictures: [
+            {
+              id: 'profile_1',
+              accountId: 'account_1',
+              takenAt,
+              filename: 'old.jpg'
+            },
+            {
+              id: 'profile_1',
+              accountId: 'account_1',
+              takenAt,
+              filename: 'new.jpg'
+            }
+          ],
+          posts: [],
+          highlights: []
+        }
+      ]
+    });
+
+    expect(prismaMock.profilePic.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.profilePic.create).toHaveBeenCalledWith({
+      data: {
+        id: 'profile_1',
+        accountId: 'account_1',
+        takenAt,
+        filename: 'new.jpg'
+      }
+    });
+    expect(result.profilePicsSynced).toBe(1);
+  });
+});

--- a/backend/src/services/uploadedReconcilerService.ts
+++ b/backend/src/services/uploadedReconcilerService.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { prisma } from '../db/client.js';
 import { resolveUploadedRoot } from '../utils/sourceRoot.js';
 
+const DB_BATCH_SIZE = 500;
+
 export type UploadedReconcilerStatus = 'idle' | 'running' | 'success' | 'failure';
 
 export type UploadedReconcileOptions = {
@@ -98,47 +100,55 @@ async function runUploadedReconcile(options: UploadedReconcileOptions = {}): Pro
   const orphanCutoffMs = nowMs - cleanOrphanOlderThanDays * 24 * 60 * 60 * 1000;
   const deletedDbCutoff = new Date(nowMs - pruneDeletedDbOlderThanDays * 24 * 60 * 60 * 1000);
 
-  const [uploadedFiles, dbRows] = await Promise.all([
-    collectUploadedFiles(uploadedRoot),
-    prisma.sharedMedia.findMany({
+  const uploadedFiles = await collectUploadedFiles(uploadedRoot);
+  const scannedFiles = uploadedFiles.size;
+
+  let dbRowsScanned = 0;
+  let missingFileRows = 0;
+  let sizeRecalculated = 0;
+  let cursorId: string | undefined;
+
+  while (true) {
+    const dbRows = await prisma.sharedMedia.findMany({
       select: {
         id: true,
         filename: true,
         uploadedAt: true,
-        isDeleted: true,
         size: true
-      }
-    })
-  ]);
-
-  const dbRelativePaths = new Map<string, { id: string; isDeleted: boolean; size: number }>();
-  for (const row of dbRows) {
-    dbRelativePaths.set(getUploadRelativePath(row.uploadedAt, row.filename), {
-      id: row.id,
-      isDeleted: row.isDeleted,
-      size: row.size
+      },
+      orderBy: { id: 'asc' },
+      take: DB_BATCH_SIZE,
+      ...(cursorId ? { cursor: { id: cursorId }, skip: 1 } : {})
     });
-  }
 
-  let missingFileRows = 0;
-  let sizeRecalculated = 0;
-  for (const [relativePath, row] of dbRelativePaths.entries()) {
-    const fileInfo = uploadedFiles.get(relativePath);
-    if (!fileInfo) {
-      missingFileRows += 1;
-      continue;
+    if (dbRows.length === 0) {
+      break;
     }
 
-    if (recalculateSize) {
-      const fileStats = await stat(fileInfo.absolutePath);
-      if (fileStats.size !== row.size && !dryRun) {
-        await prisma.sharedMedia.update({ where: { id: row.id }, data: { size: Number(fileStats.size) } });
-        sizeRecalculated += 1;
+    dbRowsScanned += dbRows.length;
+    cursorId = dbRows[dbRows.length - 1].id;
+
+    for (const row of dbRows) {
+      const relativePath = getUploadRelativePath(row.uploadedAt, row.filename);
+      const fileInfo = uploadedFiles.get(relativePath);
+      if (!fileInfo) {
+        missingFileRows += 1;
+        continue;
+      }
+
+      uploadedFiles.delete(relativePath);
+
+      if (recalculateSize) {
+        const fileStats = await stat(fileInfo.absolutePath);
+        if (fileStats.size !== row.size && !dryRun) {
+          await prisma.sharedMedia.update({ where: { id: row.id }, data: { size: Number(fileStats.size) } });
+          sizeRecalculated += 1;
+        }
       }
     }
   }
 
-  const orphanCandidates = [...uploadedFiles.entries()].filter(([relativePath]) => !dbRelativePaths.has(relativePath));
+  const orphanCandidates = [...uploadedFiles.entries()];
 
   let orphanFilesDeleted = 0;
   if (!dryRun) {
@@ -147,8 +157,12 @@ async function runUploadedReconcile(options: UploadedReconcileOptions = {}): Pro
         continue;
       }
 
-      await unlink(file.absolutePath);
-      orphanFilesDeleted += 1;
+      try {
+        await unlink(file.absolutePath);
+        orphanFilesDeleted += 1;
+      } catch (error) {
+        console.warn('Failed to delete orphan uploaded file', { path: file.absolutePath, error });
+      }
     }
   }
 
@@ -165,8 +179,8 @@ async function runUploadedReconcile(options: UploadedReconcileOptions = {}): Pro
   }
 
   return {
-    scannedFiles: uploadedFiles.size,
-    dbRowsScanned: dbRows.length,
+    scannedFiles,
+    dbRowsScanned,
     missingFileRows,
     orphanFiles: orphanCandidates.length,
     orphanFilesDeleted,

--- a/backend/src/types/prisma.d.ts
+++ b/backend/src/types/prisma.d.ts
@@ -206,16 +206,20 @@ declare module '@prisma/client' {
     profilePic: {
       deleteMany(...args: any[]): Promise<any>;
       createMany(...args: any[]): Promise<any>;
+      create(...args: any[]): Promise<ProfilePic>;
       findMany(...args: any[]): Promise<ProfilePic[]>;
+      update(...args: any[]): Promise<ProfilePic>;
     };
     tag: {
       findMany(...args: any[]): Promise<Tag[]>;
       upsert(...args: any[]): Promise<Tag>;
+      createMany(...args: any[]): Promise<any>;
       count(...args: any[]): Promise<number>;
     };
     postTag: {
       deleteMany(...args: any[]): Promise<any>;
       create(...args: any[]): Promise<PostTag>;
+      createMany(...args: any[]): Promise<any>;
     };
     postText: {
       upsert(...args: any[]): Promise<PostText>;
@@ -237,7 +241,7 @@ declare module '@prisma/client' {
       create(...args: any[]): Promise<HighlightMedia>;
     }
 
-    $transaction<T>(handler: (client: PrismaClient) => Promise<T>): Promise<T>;
+    $transaction<T>(handler: (client: PrismaClient) => Promise<T>, options?: { timeout?: number }): Promise<T>;
     $transaction<T>(operations: any[]): Promise<T>;
   }
 }

--- a/backend/src/utils/sourceRoot.test.ts
+++ b/backend/src/utils/sourceRoot.test.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveSourceRoot, resolveUploadedRoot } from './sourceRoot.js';
+
+const originalDataRoot = process.env.DATA_ROOT;
+const originalCrawlOutputDir = process.env.CRAWL_OUTPUT_DIR;
+
+describe('source root resolution', () => {
+  beforeEach(() => {
+    delete process.env.DATA_ROOT;
+    delete process.env.CRAWL_OUTPUT_DIR;
+  });
+
+  afterEach(() => {
+    if (originalDataRoot === undefined) {
+      delete process.env.DATA_ROOT;
+    } else {
+      process.env.DATA_ROOT = originalDataRoot;
+    }
+
+    if (originalCrawlOutputDir === undefined) {
+      delete process.env.CRAWL_OUTPUT_DIR;
+    } else {
+      process.env.CRAWL_OUTPUT_DIR = originalCrawlOutputDir;
+    }
+  });
+
+  it('keeps default source and uploaded roots under /data', () => {
+    expect(resolveSourceRoot()).toBe(path.resolve('/data/source'));
+    expect(resolveUploadedRoot()).toBe(path.resolve('/data/uploaded'));
+  });
+
+  it('prefers CRAWL_OUTPUT_DIR over DATA_ROOT for source reads', () => {
+    process.env.DATA_ROOT = '/tmp/fromistargram-data';
+    process.env.CRAWL_OUTPUT_DIR = '/tmp/fromistargram-crawl';
+
+    expect(resolveSourceRoot()).toBe(path.resolve('/tmp/fromistargram-crawl'));
+    expect(resolveUploadedRoot()).toBe(path.resolve('/tmp/fromistargram-data/uploaded'));
+  });
+});

--- a/backend/src/utils/sourceRoot.ts
+++ b/backend/src/utils/sourceRoot.ts
@@ -11,7 +11,7 @@ export function resolveSourceRoot(): string {
     return path.resolve(dataRoot, 'source');
   }
 
-  return path.resolve('/root');
+  return path.resolve('/data/source');
 }
 
 export function resolveSourceAccountPath(accountId: string): string {


### PR DESCRIPTION
## Summary
- process uploaded reconciler database rows in cursor batches instead of loading all shared media at once
- keep reconciliation running when one orphan file deletion fails
- restore default source root to /data/source and add regression coverage
- remove indexer transaction any-casts and update existing profile pictures when metadata changes
- extend local Prisma type declarations for the delegate methods used by the indexer

## Verification
- pnpm --filter @fromistargram/backend test
- pnpm -r lint
- pnpm -r build
- git diff --check

Follow-up for PR #49 review threads. Vite build still reports the existing baseline-browser-mapping freshness warning; build succeeds.