### PR TITLE
fix: allow identical mobile ingest uploads

### DIFF
--- a/backend/src/routes/__tests__/posts.contract.test.ts
+++ b/backend/src/routes/__tests__/posts.contract.test.ts
@@ -1,5 +1,9 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { buildServer, type BuildServerOptions } from '../../server.js';
+import { writeSourceFileAllowingIdenticalOverwrite } from '../registerMobileIngestRoutes.js';
 
 vi.mock('../../db/client.js', () => ({
   prisma: {}
@@ -107,5 +111,52 @@ describe('Post routes contract', () => {
   it('returns 404 when post is missing', async () => {
     const response = await app.inject({ method: 'GET', url: '/api/posts/unknown' });
     expect(response.statusCode).toBe(404);
+  });
+});
+
+describe('mobile ingest source file writes', () => {
+  let tempDir: string | null = null;
+
+  async function createTempFilePath(filename: string): Promise<string> {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'fromistargram-mobile-ingest-'));
+    return path.join(tempDir, filename);
+  }
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it('writes a new source file', async () => {
+    const filepath = await createTempFilePath('new.jpg');
+
+    await writeSourceFileAllowingIdenticalOverwrite(filepath, Buffer.from('image-data'));
+
+    await expect(readFile(filepath, 'utf8')).resolves.toBe('image-data');
+  });
+
+  it('allows overwriting an existing source file when content is identical', async () => {
+    const filepath = await createTempFilePath('same.jpg');
+    await writeFile(filepath, Buffer.from('same-image-data'));
+
+    await writeSourceFileAllowingIdenticalOverwrite(filepath, Buffer.from('same-image-data'));
+
+    await expect(readFile(filepath, 'utf8')).resolves.toBe('same-image-data');
+  });
+
+  it('rejects an existing source file when content differs', async () => {
+    const filepath = await createTempFilePath('different.jpg');
+    await writeFile(filepath, Buffer.from('old-image-data'));
+
+    await expect(
+      writeSourceFileAllowingIdenticalOverwrite(filepath, Buffer.from('new-image-data'))
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      statusCode: 409
+    });
+
+    await expect(readFile(filepath, 'utf8')).resolves.toBe('old-image-data');
   });
 });

--- a/backend/src/routes/registerMobileIngestRoutes.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { MultipartFile } from '@fastify/multipart';
-import { access, mkdir, writeFile } from 'fs/promises';
+import { mkdir, readFile, writeFile } from 'fs/promises';
 import path from 'path';
 import { randomUUID } from 'node:crypto';
 import { prisma } from '../db/client.js';
@@ -193,30 +193,45 @@ function generateSharedFilename(originalFilename: string, postedAt: ParsedPosted
   return `${postedAt.timestampBase}${fileSuffix}`;
 }
 
-async function fileExists(filepath: string): Promise<boolean> {
+function toComparableBuffer(data: Buffer | string): Buffer {
+  return Buffer.isBuffer(data) ? data : Buffer.from(data);
+}
+
+async function isExistingFileIdentical(filepath: string, data: Buffer | string): Promise<boolean> {
+  const existing = await readFile(filepath);
+  return existing.equals(toComparableBuffer(data));
+}
+
+async function ensureSourceFileCanBeWritten(filepath: string, data: Buffer | string): Promise<void> {
   try {
-    await access(filepath);
-    return true;
-  } catch {
-    return false;
+    const isIdentical = await isExistingFileIdentical(filepath, data);
+    if (isIdentical) {
+      return;
+    }
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return;
+    }
+
+    throw error;
   }
+
+  throw new IngestClientError(
+    `Source file already exists with different content: ${path.basename(filepath)}`,
+    409,
+    'CONFLICT'
+  );
 }
 
-async function rejectExistingSourceFiles(filepaths: string[]): Promise<void> {
-  const existingFilepath = (await Promise.all(
-    filepaths.map(async (filepath) => await fileExists(filepath) ? filepath : null)
-  )).find((filepath): filepath is string => filepath !== null);
-
-  if (existingFilepath) {
-    throw new IngestClientError(
-      `Source file already exists: ${path.basename(existingFilepath)}`,
-      409,
-      'CONFLICT'
-    );
-  }
-}
-
-async function writeNewSourceFile(filepath: string, data: Buffer | string): Promise<void> {
+export async function writeSourceFileAllowingIdenticalOverwrite(
+  filepath: string,
+  data: Buffer | string
+): Promise<void> {
   try {
     await writeFile(filepath, data, { flag: 'wx' });
   } catch (error) {
@@ -226,11 +241,9 @@ async function writeNewSourceFile(filepath: string, data: Buffer | string): Prom
       'code' in error &&
       error.code === 'EEXIST'
     ) {
-      throw new IngestClientError(
-        `Source file already exists: ${path.basename(filepath)}`,
-        409,
-        'CONFLICT'
-      );
+      await ensureSourceFileCanBeWritten(filepath, data);
+      await writeFile(filepath, data);
+      return;
     }
 
     throw error;
@@ -431,34 +444,39 @@ async function saveToSource(input: {
 
   const metadataFilename = `${input.postedAt.timestampBase}_UTC.json`;
   const metadataPath = path.join(sourceDir, metadataFilename);
-  await rejectExistingSourceFiles([
-    ...mediaFiles.map((file) => file.filepath),
-    ...(captionPath ? [captionPath] : []),
-    metadataPath
-  ]);
+  const metadataContent = JSON.stringify(
+    {
+      instaloader: {
+        node_type: input.type === 'Story' ? 'StoryItem' : 'Post'
+      }
+    },
+    null,
+    2
+  );
+  const sourceFiles = [
+    ...mediaFiles.map((file) => ({ filepath: file.filepath, data: file.buffer })),
+    ...(captionPath !== null && input.caption !== undefined
+      ? [{ filepath: captionPath, data: input.caption }]
+      : []),
+    {
+      filepath: metadataPath,
+      data: metadataContent
+    }
+  ];
+
+  await Promise.all(sourceFiles.map((file) => ensureSourceFileCanBeWritten(file.filepath, file.data)));
 
   const savedFiles: Array<{ filename: string; filepath: string }> = [];
   for (const file of mediaFiles) {
-    await writeNewSourceFile(file.filepath, file.buffer);
+    await writeSourceFileAllowingIdenticalOverwrite(file.filepath, file.buffer);
     savedFiles.push({ filename: file.filename, filepath: file.filepath });
   }
 
   if (captionPath !== null && input.caption !== undefined) {
-    await writeNewSourceFile(captionPath, input.caption);
+    await writeSourceFileAllowingIdenticalOverwrite(captionPath, input.caption);
   }
 
-  await writeNewSourceFile(
-    metadataPath,
-    JSON.stringify(
-      {
-        instaloader: {
-          node_type: input.type === 'Story' ? 'StoryItem' : 'Post'
-        }
-      },
-      null,
-      2
-    )
-  );
+  await writeSourceFileAllowingIdenticalOverwrite(metadataPath, metadataContent);
 
   const postId = `${input.postedAt.timestampBase}_UTC`;
   const apiBaseUrl = getApiBaseUrl(input.request);

--- a/backend/src/routes/registerMobileIngestRoutes.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { MultipartFile } from '@fastify/multipart';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile, stat, writeFile } from 'fs/promises';
 import path from 'path';
 import { randomUUID } from 'node:crypto';
 import { prisma } from '../db/client.js';
@@ -198,8 +198,14 @@ function toComparableBuffer(data: Buffer | string): Buffer {
 }
 
 async function isExistingFileIdentical(filepath: string, data: Buffer | string): Promise<boolean> {
+  const buffer = toComparableBuffer(data);
+  const existingStats = await stat(filepath);
+  if (existingStats.size !== buffer.length) {
+    return false;
+  }
+
   const existing = await readFile(filepath);
-  return existing.equals(toComparableBuffer(data));
+  return existing.equals(buffer);
 }
 
 async function ensureSourceFileCanBeWritten(filepath: string, data: Buffer | string): Promise<void> {
@@ -242,7 +248,6 @@ export async function writeSourceFileAllowingIdenticalOverwrite(
       error.code === 'EEXIST'
     ) {
       await ensureSourceFileCanBeWritten(filepath, data);
-      await writeFile(filepath, data);
       return;
     }
 
@@ -464,7 +469,9 @@ async function saveToSource(input: {
     }
   ];
 
-  await Promise.all(sourceFiles.map((file) => ensureSourceFileCanBeWritten(file.filepath, file.data)));
+  for (const file of sourceFiles) {
+    await ensureSourceFileCanBeWritten(file.filepath, file.data);
+  }
 
   const savedFiles: Array<{ filename: string; filepath: string }> = [];
   for (const file of mediaFiles) {


### PR DESCRIPTION
## Summary
- Allow mobile ingest source uploads to proceed when an existing same-name file has identical content, rewriting the same bytes instead of returning a duplicate-file conflict.
- Preserve 409 CONFLICT behavior when the same filename already exists with different content.
- Add regression coverage for new file writes, identical overwrites, and different-content conflicts.

## Testing
- npm --prefix backend run lint
- npm --prefix backend test