### PR TITLE
fix: group story indexer posts by KST day

### DIFF
--- a/backend/src/indexer/fileSystemScanner.test.ts
+++ b/backend/src/indexer/fileSystemScanner.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { scanDataRoot } from './fileSystemScanner.js';
+
+let tempRoots: string[] = [];
+
+async function createDataRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'fromistargram-indexer-'));
+  tempRoots.push(root);
+  return root;
+}
+
+async function writeStoryItem(
+  accountDir: string,
+  timestamp: string,
+  mediaContent: string,
+  textContent: string
+): Promise<void> {
+  await writeFile(
+    path.join(accountDir, `${timestamp}_UTC.json`),
+    JSON.stringify({ instaloader: { node_type: 'StoryItem' } })
+  );
+  await writeFile(path.join(accountDir, `${timestamp}_UTC.jpg`), mediaContent);
+  await writeFile(path.join(accountDir, `${timestamp}_UTC.txt`), textContent);
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })));
+  tempRoots = [];
+});
+
+describe('scanDataRoot story grouping', () => {
+  it('groups stories by KST date, deduplicates media, and merges text chronologically', async () => {
+    const dataRoot = await createDataRoot();
+    const accountDir = path.join(dataRoot, 'openai');
+    await mkdir(accountDir);
+
+    await writeStoryItem(
+      accountDir,
+      '2026-05-14_14-30-00',
+      'same image bytes',
+      'newer story #ai'
+    );
+    await writeStoryItem(
+      accountDir,
+      '2026-05-13_15-30-00',
+      'same image bytes',
+      'older story #ml'
+    );
+    await writeStoryItem(
+      accountDir,
+      '2026-05-14_15-10-00',
+      'next date image bytes',
+      'next KST day'
+    );
+
+    const snapshot = await scanDataRoot(dataRoot);
+    const posts = snapshot.accounts[0]?.posts ?? [];
+    const may14Story = posts.find((post) => post.id === '2026-05-14_KST_story_openai');
+    const may15Story = posts.find((post) => post.id === '2026-05-15_KST_story_openai');
+
+    expect(may14Story).toMatchObject({
+      accountId: 'openai',
+      type: 'Story',
+      textContent: 'older story #ml\n\nnewer story #ai',
+      caption: 'older story #ml\n\nnewer story #ai',
+      tags: ['ml', 'ai']
+    });
+    expect(may14Story?.postedAt.toISOString()).toBe('2026-05-14T14:30:00.000Z');
+    expect(may14Story?.media).toHaveLength(1);
+    expect(may14Story?.media[0]).not.toHaveProperty('contentHash');
+    expect(may14Story?.media[0]).not.toHaveProperty('sourcePath');
+    expect(may15Story?.media).toHaveLength(1);
+  });
+});

--- a/backend/src/indexer/fileSystemScanner.ts
+++ b/backend/src/indexer/fileSystemScanner.ts
@@ -1,4 +1,6 @@
+import { createReadStream } from 'fs';
 import { readdir, readFile } from 'fs/promises';
+import { createHash } from 'node:crypto';
 import path from 'path';
 import { lookup } from 'mime-types';
 import { extractHashtags } from '../utils/hashtags.js';
@@ -17,23 +19,147 @@ const TEXT_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC\.txt$
 const PROFILE_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC_profile_pic\.(?<extension>[a-zA-Z0-9]+)$/;
 const COVER_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC_cover\.(?<extension>[a-zA-Z0-9]+)$/;
 
+type AccumulatedMedia = IndexedMedia & {
+  contentHash: string;
+};
+
 function parseTimestamp(timestamp: string): Date {
   const [datePart, timePart] = timestamp.split('_');
   const normalizedTime = timePart.replace(/-/g, ':');
   return new Date(`${datePart}T${normalizedTime}Z`);
 }
 
+function formatKstDateKey(date: Date): string {
+  const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  const year = kstDate.getUTCFullYear();
+  const month = String(kstDate.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(kstDate.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function buildStoryGroupId(accountId: string, dateKey: string): string {
+  return `${dateKey}_KST_story_${accountId}`;
+}
+
+function mergeTextContent(current: string | null, next: string | null): string | null {
+  if (!next) {
+    return current;
+  }
+
+  if (!current) {
+    return next;
+  }
+
+  return `${current.trimEnd()}\n\n${next}`;
+}
+
+async function hashFile(filepath: string): Promise<string> {
+  const hash = createHash('sha256');
+  for await (const chunk of createReadStream(filepath)) {
+    hash.update(chunk);
+  }
+
+  return hash.digest('hex');
+}
+
 type PostAccumulator = {
   id: string;
   accountId: string;
   postedAt: Date;
-  media: IndexedMedia[];
+  media: AccumulatedMedia[];
   textContent: string | null;
   hasText: boolean;
   tags: Set<string>;
   caption: string | null;
   type: string;
 };
+
+function mergeStoryIntoGroup(group: PostAccumulator, story: PostAccumulator): void {
+  if (story.postedAt.getTime() > group.postedAt.getTime()) {
+    group.postedAt = story.postedAt;
+  }
+
+  const existingHashes = new Set(group.media.map((media) => media.contentHash));
+  for (const media of story.media) {
+    if (existingHashes.has(media.contentHash)) {
+      continue;
+    }
+
+    existingHashes.add(media.contentHash);
+    group.media.push(media);
+  }
+  group.textContent = mergeTextContent(group.textContent, story.textContent);
+  group.caption = mergeTextContent(group.caption, story.caption);
+  group.hasText = group.hasText || story.hasText;
+  story.tags.forEach((tag) => group.tags.add(tag));
+}
+
+function groupStoriesByDay(posts: PostAccumulator[]): PostAccumulator[] {
+  const groupedPosts: PostAccumulator[] = [];
+  const storyGroups = new Map<string, PostAccumulator>();
+
+  for (const post of posts) {
+    if (post.type !== 'Story') {
+      groupedPosts.push(post);
+      continue;
+    }
+
+    const dateKey = formatKstDateKey(post.postedAt);
+    const groupKey = `${post.accountId}:${dateKey}`;
+    const existingGroup = storyGroups.get(groupKey);
+    if (existingGroup) {
+      mergeStoryIntoGroup(existingGroup, post);
+      continue;
+    }
+
+    const group: PostAccumulator = {
+      ...post,
+      id: buildStoryGroupId(post.accountId, dateKey),
+      media: [...post.media],
+      tags: new Set(post.tags)
+    };
+    storyGroups.set(groupKey, group);
+    groupedPosts.push(group);
+  }
+
+  return groupedPosts;
+}
+
+function getMediaTimestamp(filename: string): string {
+  const match = path.basename(filename).match(MEDIA_REGEX);
+  return match?.groups?.timestamp ?? '';
+}
+
+function compareIndexedMedia(a: IndexedMedia, b: IndexedMedia, postType: string): number {
+  if (postType === 'Story') {
+    return getMediaTimestamp(a.filename).localeCompare(getMediaTimestamp(b.filename)) ||
+      a.orderIndex - b.orderIndex ||
+      a.filename.localeCompare(b.filename);
+  }
+
+  return a.orderIndex - b.orderIndex || a.filename.localeCompare(b.filename);
+}
+
+function toIndexedPost(post: PostAccumulator): IndexedPost {
+  const media = [...post.media]
+    .sort((a, b) => compareIndexedMedia(a, b, post.type))
+    .map(({ contentHash: _contentHash, ...item }, index) => ({
+      ...item,
+      orderIndex: index
+    }));
+
+  return {
+    id: post.id,
+    accountId: post.accountId,
+    postedAt: post.postedAt,
+    media,
+    caption: post.caption,
+    hasText: post.hasText,
+    textContent: post.textContent,
+    tags: Array.from(post.tags),
+    type: post.type
+  };
+}
 
 async function scanAccount(dataRoot: string, accountId: string): Promise<AccountSnapshot> {
   const accountDir = path.join(dataRoot, accountId);
@@ -204,7 +330,8 @@ async function scanAccount(dataRoot: string, accountId: string): Promise<Account
         mime: typeof mime === 'string' ? mime : 'application/octet-stream',
         width: null,
         height: null,
-        duration: null
+        duration: null,
+        contentHash: await hashFile(absolutePath)
       });
       continue;
     }
@@ -221,19 +348,9 @@ async function scanAccount(dataRoot: string, accountId: string): Promise<Account
     }
   }
 
-  const posts: IndexedPost[] = Array.from(postMap.values())
+  const posts: IndexedPost[] = groupStoriesByDay(Array.from(postMap.values()))
     .sort((a, b) => b.postedAt.getTime() - a.postedAt.getTime())
-    .map((post) => ({
-      id: post.id,
-      accountId: post.accountId,
-      postedAt: post.postedAt,
-      media: [...post.media].sort((a, b) => a.orderIndex - b.orderIndex),
-      caption: post.caption,
-      hasText: post.hasText,
-      textContent: post.textContent,
-      tags: Array.from(post.tags),
-      type: post.type
-    }));
+    .map(toIndexedPost);
 
   profilePictures.sort((a, b) => a.takenAt.getTime() - b.takenAt.getTime());
 

--- a/backend/src/indexer/fileSystemScanner.ts
+++ b/backend/src/indexer/fileSystemScanner.ts
@@ -20,7 +20,8 @@ const PROFILE_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC_pr
 const COVER_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC_cover\.(?<extension>[a-zA-Z0-9]+)$/;
 
 type AccumulatedMedia = IndexedMedia & {
-  contentHash: string;
+  contentHash?: string;
+  sourcePath: string;
 };
 
 function parseTimestamp(timestamp: string): Date {
@@ -30,10 +31,16 @@ function parseTimestamp(timestamp: string): Date {
 }
 
 function formatKstDateKey(date: Date): string {
-  const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
-  const year = kstDate.getUTCFullYear();
-  const month = String(kstDate.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(kstDate.getUTCDate()).padStart(2, '0');
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).formatToParts(date);
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const year = values.year;
+  const month = values.month;
+  const day = values.day;
   return `${year}-${month}-${day}`;
 }
 
@@ -81,7 +88,7 @@ function mergeStoryIntoGroup(group: PostAccumulator, story: PostAccumulator): vo
 
   const existingHashes = new Set(group.media.map((media) => media.contentHash));
   for (const media of story.media) {
-    if (existingHashes.has(media.contentHash)) {
+    if (media.contentHash && existingHashes.has(media.contentHash)) {
       continue;
     }
 
@@ -94,9 +101,19 @@ function mergeStoryIntoGroup(group: PostAccumulator, story: PostAccumulator): vo
   story.tags.forEach((tag) => group.tags.add(tag));
 }
 
+function compareStoryAccumulators(a: PostAccumulator, b: PostAccumulator): number {
+  return a.postedAt.getTime() - b.postedAt.getTime() || a.id.localeCompare(b.id);
+}
+
 function groupStoriesByDay(posts: PostAccumulator[]): PostAccumulator[] {
   const groupedPosts: PostAccumulator[] = [];
-  const storyGroups = new Map<string, PostAccumulator>();
+  const storyGroups = new Map<
+    string,
+    {
+      dateKey: string;
+      stories: PostAccumulator[];
+    }
+  >();
 
   for (const post of posts) {
     if (post.type !== 'Story') {
@@ -108,17 +125,30 @@ function groupStoriesByDay(posts: PostAccumulator[]): PostAccumulator[] {
     const groupKey = `${post.accountId}:${dateKey}`;
     const existingGroup = storyGroups.get(groupKey);
     if (existingGroup) {
-      mergeStoryIntoGroup(existingGroup, post);
+      existingGroup.stories.push(post);
       continue;
     }
 
+    storyGroups.set(groupKey, {
+      dateKey,
+      stories: [post]
+    });
+  }
+
+  for (const { dateKey, stories } of storyGroups.values()) {
+    const sortedStories = [...stories].sort(compareStoryAccumulators);
+    const [firstStory, ...remainingStories] = sortedStories;
     const group: PostAccumulator = {
-      ...post,
-      id: buildStoryGroupId(post.accountId, dateKey),
-      media: [...post.media],
-      tags: new Set(post.tags)
+      ...firstStory,
+      id: buildStoryGroupId(firstStory.accountId, dateKey),
+      media: [...firstStory.media],
+      tags: new Set(firstStory.tags)
     };
-    storyGroups.set(groupKey, group);
+
+    for (const story of remainingStories) {
+      mergeStoryIntoGroup(group, story);
+    }
+
     groupedPosts.push(group);
   }
 
@@ -143,7 +173,7 @@ function compareIndexedMedia(a: IndexedMedia, b: IndexedMedia, postType: string)
 function toIndexedPost(post: PostAccumulator): IndexedPost {
   const media = [...post.media]
     .sort((a, b) => compareIndexedMedia(a, b, post.type))
-    .map(({ contentHash: _contentHash, ...item }, index) => ({
+    .map(({ contentHash: _contentHash, sourcePath: _sourcePath, ...item }, index) => ({
       ...item,
       orderIndex: index
     }));
@@ -331,7 +361,7 @@ async function scanAccount(dataRoot: string, accountId: string): Promise<Account
         width: null,
         height: null,
         duration: null,
-        contentHash: await hashFile(absolutePath)
+        sourcePath: absolutePath
       });
       continue;
     }
@@ -348,7 +378,18 @@ async function scanAccount(dataRoot: string, accountId: string): Promise<Account
     }
   }
 
-  const posts: IndexedPost[] = groupStoriesByDay(Array.from(postMap.values()))
+  const accumulatedPosts = Array.from(postMap.values());
+  await Promise.all(
+    accumulatedPosts
+      .filter((post) => post.type === 'Story')
+      .flatMap((post) =>
+        post.media.map(async (media) => {
+          media.contentHash = await hashFile(media.sourcePath);
+        })
+      )
+  );
+
+  const posts: IndexedPost[] = groupStoriesByDay(accumulatedPosts)
     .sort((a, b) => b.postedAt.getTime() - a.postedAt.getTime())
     .map(toIndexedPost);
 

--- a/backend/src/indexer/indexer.test.ts
+++ b/backend/src/indexer/indexer.test.ts
@@ -67,4 +67,116 @@ describe('buildSnapshot', () => {
       ]
     });
   });
+
+  it('groups story media from the same KST day into one indexed post', async () => {
+    const dataRoot = await createTempDataRoot();
+    const accountDir = path.join(dataRoot, 'test_account');
+    await mkdir(accountDir, { recursive: true });
+
+    await writeFile(path.join(accountDir, '2026-05-01_15-30-00_UTC.jpg'), 'story-one');
+    await writeFile(
+      path.join(accountDir, '2026-05-01_15-30-00_UTC.json'),
+      JSON.stringify({ instaloader: { node_type: 'StoryItem' } })
+    );
+    await writeFile(path.join(accountDir, '2026-05-02_03-00-00_UTC.jpg'), 'story-two');
+    await writeFile(
+      path.join(accountDir, '2026-05-02_03-00-00_UTC.json'),
+      JSON.stringify({ instaloader: { node_type: 'StoryItem' } })
+    );
+    await writeFile(path.join(accountDir, '2026-05-02_16-00-00_UTC.jpg'), 'story-three');
+    await writeFile(
+      path.join(accountDir, '2026-05-02_16-00-00_UTC.json'),
+      JSON.stringify({ instaloader: { node_type: 'StoryItem' } })
+    );
+
+    const snapshot = await buildSnapshot({ dataRoot });
+    const posts = snapshot.accounts[0].posts;
+
+    expect(posts).toHaveLength(2);
+    expect(posts[0]).toMatchObject({
+      id: '2026-05-03_KST_story_test_account',
+      type: 'Story',
+      postedAt: new Date('2026-05-02T16:00:00.000Z'),
+      media: [
+        {
+          filename: '2026-05-02_16-00-00_UTC.jpg',
+          orderIndex: 0
+        }
+      ]
+    });
+    expect(posts[1]).toMatchObject({
+      id: '2026-05-02_KST_story_test_account',
+      type: 'Story',
+      postedAt: new Date('2026-05-02T03:00:00.000Z'),
+      media: [
+        {
+          filename: '2026-05-01_15-30-00_UTC.jpg',
+          orderIndex: 0
+        },
+        {
+          filename: '2026-05-02_03-00-00_UTC.jpg',
+          orderIndex: 1
+        }
+      ]
+    });
+  });
+
+  it('keeps regular post media ordered by filename index', async () => {
+    const dataRoot = await createTempDataRoot();
+    const accountDir = path.join(dataRoot, 'test_account');
+    await mkdir(accountDir, { recursive: true });
+
+    await writeFile(path.join(accountDir, '2026-05-01_01-00-00_UTC_2.jpg'), '');
+    await writeFile(path.join(accountDir, '2026-05-01_01-00-00_UTC_1.jpg'), '');
+
+    const snapshot = await buildSnapshot({ dataRoot });
+    const media = snapshot.accounts[0].posts[0].media;
+
+    expect(media).toMatchObject([
+      {
+        filename: '2026-05-01_01-00-00_UTC_1.jpg',
+        orderIndex: 0
+      },
+      {
+        filename: '2026-05-01_01-00-00_UTC_2.jpg',
+        orderIndex: 1
+      }
+    ]);
+  });
+
+  it('deduplicates identical story media in the same KST day', async () => {
+    const dataRoot = await createTempDataRoot();
+    const accountDir = path.join(dataRoot, 'test_account');
+    await mkdir(accountDir, { recursive: true });
+
+    await writeFile(path.join(accountDir, '2026-05-01_01-00-00_UTC.jpg'), 'same-bytes');
+    await writeFile(
+      path.join(accountDir, '2026-05-01_01-00-00_UTC.json'),
+      JSON.stringify({ instaloader: { node_type: 'StoryItem' } })
+    );
+    await writeFile(path.join(accountDir, '2026-05-01_03-00-00_UTC.jpg'), 'same-bytes');
+    await writeFile(
+      path.join(accountDir, '2026-05-01_03-00-00_UTC.json'),
+      JSON.stringify({ instaloader: { node_type: 'StoryItem' } })
+    );
+    await writeFile(path.join(accountDir, '2026-05-01_05-00-00_UTC.jpg'), 'different-bytes');
+    await writeFile(
+      path.join(accountDir, '2026-05-01_05-00-00_UTC.json'),
+      JSON.stringify({ instaloader: { node_type: 'StoryItem' } })
+    );
+
+    const snapshot = await buildSnapshot({ dataRoot });
+    const media = snapshot.accounts[0].posts[0].media;
+
+    expect(media).toMatchObject([
+      {
+        filename: '2026-05-01_01-00-00_UTC.jpg',
+        orderIndex: 0
+      },
+      {
+        filename: '2026-05-01_05-00-00_UTC.jpg',
+        orderIndex: 1
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- group indexed Story posts by UTC+9/KST calendar day instead of raw UTC day
- use stable KST story group ids
- add indexer coverage for KST day boundaries, regular post ordering, and duplicate story media

## Tests
- pnpm test