### PR TITLE
fix: delete indexed post children before posts

### DIFF
--- a/backend/src/indexer/fileSystemScanner.ts
+++ b/backend/src/indexer/fileSystemScanner.ts
@@ -20,8 +20,7 @@ const PROFILE_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC_pr
 const COVER_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC_cover\.(?<extension>[a-zA-Z0-9]+)$/;
 
 type AccumulatedMedia = IndexedMedia & {
-  contentHash?: string;
-  sourcePath: string;
+  contentHash: string;
 };
 
 function parseTimestamp(timestamp: string): Date {
@@ -88,7 +87,7 @@ function mergeStoryIntoGroup(group: PostAccumulator, story: PostAccumulator): vo
 
   const existingHashes = new Set(group.media.map((media) => media.contentHash));
   for (const media of story.media) {
-    if (media.contentHash && existingHashes.has(media.contentHash)) {
+    if (existingHashes.has(media.contentHash)) {
       continue;
     }
 
@@ -173,7 +172,7 @@ function compareIndexedMedia(a: IndexedMedia, b: IndexedMedia, postType: string)
 function toIndexedPost(post: PostAccumulator): IndexedPost {
   const media = [...post.media]
     .sort((a, b) => compareIndexedMedia(a, b, post.type))
-    .map(({ contentHash: _contentHash, sourcePath: _sourcePath, ...item }, index) => ({
+    .map(({ contentHash: _contentHash, ...item }, index) => ({
       ...item,
       orderIndex: index
     }));
@@ -361,7 +360,7 @@ async function scanAccount(dataRoot: string, accountId: string): Promise<Account
         width: null,
         height: null,
         duration: null,
-        sourcePath: absolutePath
+        contentHash: await hashFile(absolutePath)
       });
       continue;
     }
@@ -379,16 +378,6 @@ async function scanAccount(dataRoot: string, accountId: string): Promise<Account
   }
 
   const accumulatedPosts = Array.from(postMap.values());
-  await Promise.all(
-    accumulatedPosts
-      .filter((post) => post.type === 'Story')
-      .flatMap((post) =>
-        post.media.map(async (media) => {
-          media.contentHash = await hashFile(media.sourcePath);
-        })
-      )
-  );
-
   const posts: IndexedPost[] = groupStoriesByDay(accumulatedPosts)
     .sort((a, b) => b.postedAt.getTime() - a.postedAt.getTime())
     .map(toIndexedPost);

--- a/backend/src/indexer/fileSystemScanner.ts
+++ b/backend/src/indexer/fileSystemScanner.ts
@@ -20,7 +20,8 @@ const PROFILE_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC_pr
 const COVER_REGEX = /^(?<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})_UTC_cover\.(?<extension>[a-zA-Z0-9]+)$/;
 
 type AccumulatedMedia = IndexedMedia & {
-  contentHash: string;
+  contentHash?: string;
+  sourcePath: string;
 };
 
 function parseTimestamp(timestamp: string): Date {
@@ -87,7 +88,7 @@ function mergeStoryIntoGroup(group: PostAccumulator, story: PostAccumulator): vo
 
   const existingHashes = new Set(group.media.map((media) => media.contentHash));
   for (const media of story.media) {
-    if (existingHashes.has(media.contentHash)) {
+    if (media.contentHash && existingHashes.has(media.contentHash)) {
       continue;
     }
 
@@ -172,7 +173,7 @@ function compareIndexedMedia(a: IndexedMedia, b: IndexedMedia, postType: string)
 function toIndexedPost(post: PostAccumulator): IndexedPost {
   const media = [...post.media]
     .sort((a, b) => compareIndexedMedia(a, b, post.type))
-    .map(({ contentHash: _contentHash, ...item }, index) => ({
+    .map(({ contentHash: _contentHash, sourcePath: _sourcePath, ...item }, index) => ({
       ...item,
       orderIndex: index
     }));
@@ -360,7 +361,7 @@ async function scanAccount(dataRoot: string, accountId: string): Promise<Account
         width: null,
         height: null,
         duration: null,
-        contentHash: await hashFile(absolutePath)
+        sourcePath: absolutePath
       });
       continue;
     }
@@ -378,6 +379,16 @@ async function scanAccount(dataRoot: string, accountId: string): Promise<Account
   }
 
   const accumulatedPosts = Array.from(postMap.values());
+  await Promise.all(
+    accumulatedPosts
+      .filter((post) => post.type === 'Story')
+      .flatMap((post) =>
+        post.media.map(async (media) => {
+          media.contentHash = await hashFile(media.sourcePath);
+        })
+      )
+  );
+
   const posts: IndexedPost[] = groupStoriesByDay(accumulatedPosts)
     .sort((a, b) => b.postedAt.getTime() - a.postedAt.getTime())
     .map(toIndexedPost);

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -149,10 +149,12 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
       .map((post) => post.id);
 
     if (deletedPostIds.length > 0) {
-      await prisma.media.deleteMany({ where: { postId: { in: deletedPostIds } } });
-      await prisma.postText.deleteMany({ where: { postId: { in: deletedPostIds } } });
-      await prisma.postTag.deleteMany({ where: { postId: { in: deletedPostIds } } });
-      await prisma.post.deleteMany({ where: { id: { in: deletedPostIds } } });
+      await prisma.$transaction([
+        prisma.media.deleteMany({ where: { postId: { in: deletedPostIds } } }),
+        prisma.postText.deleteMany({ where: { postId: { in: deletedPostIds } } }),
+        prisma.postTag.deleteMany({ where: { postId: { in: deletedPostIds } } }),
+        prisma.post.deleteMany({ where: { id: { in: deletedPostIds } } })
+      ]);
     }
 
     const postsToSync = account.posts.filter((post) => {

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -149,6 +149,9 @@ export async function syncSnapshotToDatabase(snapshot: IndexerSnapshot): Promise
       .map((post) => post.id);
 
     if (deletedPostIds.length > 0) {
+      await prisma.media.deleteMany({ where: { postId: { in: deletedPostIds } } });
+      await prisma.postText.deleteMany({ where: { postId: { in: deletedPostIds } } });
+      await prisma.postTag.deleteMany({ where: { postId: { in: deletedPostIds } } });
       await prisma.post.deleteMany({ where: { id: { in: deletedPostIds } } });
     }
 

--- a/backend/src/indexer/syncSnapshotToDatabase.test.ts
+++ b/backend/src/indexer/syncSnapshotToDatabase.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const prismaMock = {
+  $transaction: vi.fn(),
   account: {
     findUnique: vi.fn(),
     upsert: vi.fn()
@@ -57,6 +58,7 @@ describe('syncSnapshotToDatabase', () => {
     prismaMock.profilePic.update.mockResolvedValue({});
     prismaMock.highlight.findMany.mockResolvedValue([]);
     prismaMock.highlight.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.$transaction.mockImplementation(async (operations: unknown[]) => await Promise.all(operations));
     clearCacheMock.mockResolvedValue(undefined);
   });
 
@@ -131,6 +133,13 @@ describe('syncSnapshotToDatabase', () => {
     expect(prismaMock.postText.deleteMany).toHaveBeenCalledWith(childDeleteFilter);
     expect(prismaMock.postTag.deleteMany).toHaveBeenCalledWith(childDeleteFilter);
     expect(prismaMock.post.deleteMany).toHaveBeenCalledWith({ where: { id: { in: ['removed_post'] } } });
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(prismaMock.$transaction).toHaveBeenCalledWith([
+      prismaMock.media.deleteMany.mock.results[0].value,
+      prismaMock.postText.deleteMany.mock.results[0].value,
+      prismaMock.postTag.deleteMany.mock.results[0].value,
+      prismaMock.post.deleteMany.mock.results[0].value
+    ]);
 
     const mediaDeleteOrder = prismaMock.media.deleteMany.mock.invocationCallOrder[0];
     const postTextDeleteOrder = prismaMock.postText.deleteMany.mock.invocationCallOrder[0];

--- a/backend/src/indexer/syncSnapshotToDatabase.test.ts
+++ b/backend/src/indexer/syncSnapshotToDatabase.test.ts
@@ -9,6 +9,15 @@ const prismaMock = {
     findMany: vi.fn(),
     deleteMany: vi.fn()
   },
+  media: {
+    deleteMany: vi.fn()
+  },
+  postText: {
+    deleteMany: vi.fn()
+  },
+  postTag: {
+    deleteMany: vi.fn()
+  },
   profilePic: {
     findMany: vi.fn(),
     deleteMany: vi.fn(),
@@ -39,6 +48,9 @@ describe('syncSnapshotToDatabase', () => {
     prismaMock.account.upsert.mockResolvedValue({});
     prismaMock.post.findMany.mockResolvedValue([]);
     prismaMock.post.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.media.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.postText.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.postTag.deleteMany.mockResolvedValue({ count: 0 });
     prismaMock.profilePic.findMany.mockResolvedValue([]);
     prismaMock.profilePic.deleteMany.mockResolvedValue({ count: 0 });
     prismaMock.profilePic.create.mockResolvedValue({});
@@ -86,5 +98,46 @@ describe('syncSnapshotToDatabase', () => {
       }
     });
     expect(result.profilePicsSynced).toBe(1);
+  });
+
+  it('deletes post children before deleting posts removed from the snapshot', async () => {
+    const { syncSnapshotToDatabase } = await import('./indexer.js');
+    prismaMock.post.findMany.mockResolvedValue([
+      {
+        id: 'removed_post',
+        postedAt: new Date('2026-05-01T00:00:00.000Z'),
+        caption: null,
+        hasText: false,
+        type: 'Story',
+        media: [],
+        postText: null,
+        tags: []
+      }
+    ]);
+
+    await syncSnapshotToDatabase({
+      accounts: [
+        {
+          id: 'account_1',
+          profilePictures: [],
+          posts: [],
+          highlights: []
+        }
+      ]
+    });
+
+    const childDeleteFilter = { where: { postId: { in: ['removed_post'] } } };
+    expect(prismaMock.media.deleteMany).toHaveBeenCalledWith(childDeleteFilter);
+    expect(prismaMock.postText.deleteMany).toHaveBeenCalledWith(childDeleteFilter);
+    expect(prismaMock.postTag.deleteMany).toHaveBeenCalledWith(childDeleteFilter);
+    expect(prismaMock.post.deleteMany).toHaveBeenCalledWith({ where: { id: { in: ['removed_post'] } } });
+
+    const mediaDeleteOrder = prismaMock.media.deleteMany.mock.invocationCallOrder[0];
+    const postTextDeleteOrder = prismaMock.postText.deleteMany.mock.invocationCallOrder[0];
+    const postTagDeleteOrder = prismaMock.postTag.deleteMany.mock.invocationCallOrder[0];
+    const postDeleteOrder = prismaMock.post.deleteMany.mock.invocationCallOrder[0];
+    expect(mediaDeleteOrder).toBeLessThan(postDeleteOrder);
+    expect(postTextDeleteOrder).toBeLessThan(postDeleteOrder);
+    expect(postTagDeleteOrder).toBeLessThan(postDeleteOrder);
   });
 });


### PR DESCRIPTION
## Summary
- Delete indexed post child rows (`Media`, `PostText`, `PostTag`) before deleting posts that disappeared from the filesystem snapshot.
- Prevent `Media_postId_fkey` violations when story regrouping or removed files cause old post IDs to be deleted.
- Keep story duplicate media hashes attached directly to scanned media instead of doing a second source-path pass.

## Root Cause
The production database rejected `Post` deletes because rows in `Media` still referenced the removed post IDs. The Prisma schema declares cascade, but the live FK constraint is not behaving as cascade, so the indexer now deletes children explicitly before deleting parent posts.

## Testing
- npm --prefix backend test -- indexer.test.ts syncSnapshotToDatabase.test.ts
- npm --prefix backend run lint
- npm --prefix backend test