### PR TITLE
Add mobile profile photo ingest and automatic indexing

### DIFF
--- a/backend/src/indexer/fileSystemScanner.test.ts
+++ b/backend/src/indexer/fileSystemScanner.test.ts
@@ -31,6 +31,33 @@ afterEach(async () => {
   tempRoots = [];
 });
 
+describe('scanDataRoot profile photos', () => {
+  it('indexes profile-photo filenames without creating post media', async () => {
+    const dataRoot = await createDataRoot();
+    const accountDir = path.join(dataRoot, 'openai');
+    await mkdir(accountDir);
+    await writeFile(
+      path.join(accountDir, '2026-08-09_03-34-56_UTC_profile_pic.jpg'),
+      'profile bytes'
+    );
+
+    const snapshot = await scanDataRoot(dataRoot);
+
+    expect(snapshot.accounts[0]).toMatchObject({
+      id: 'openai',
+      posts: [],
+      profilePictures: [
+        {
+          id: 'openai_2026-08-09_03-34-56',
+          accountId: 'openai',
+          filename: '2026-08-09_03-34-56_UTC_profile_pic.jpg',
+          takenAt: new Date('2026-08-09T03:34:56.000Z')
+        }
+      ]
+    });
+  });
+});
+
 describe('scanDataRoot story grouping', () => {
   it('groups stories by KST date, deduplicates media, and merges text chronologically', async () => {
     const dataRoot = await createDataRoot();

--- a/backend/src/routes/registerMobileIngestRoutes.test.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.test.ts
@@ -1,6 +1,6 @@
 import Fastify, { FastifyInstance } from 'fastify';
 import multipart from '@fastify/multipart';
-import { mkdtemp, readdir, readFile, rm } from 'fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -216,6 +216,22 @@ describe('POST /api/mobile/profile-photo-ingest', () => {
     ]);
   });
 
+  it('reuses an identical legacy .jpeg file without creating a parallel .jpg', async () => {
+    const accountDir = path.join(sourceRoot!, 'test_user');
+    const legacyFilename = '2026-08-09_03-34-56_UTC_profile_pic.jpeg';
+    await mkdir(accountDir, { recursive: true });
+    await writeFile(path.join(accountDir, legacyFilename), JPEG_A);
+
+    const response = await injectProfilePhoto([...validFields]);
+
+    expect(response.statusCode).toBe(200);
+    expect(await readdir(accountDir)).toEqual([legacyFilename]);
+    expect(response.json()).toMatchObject({
+      success: true,
+      data: { filename: legacyFilename }
+    });
+  });
+
   it('serializes concurrent writes for one logical account timestamp', async () => {
     const [jpegResponse, pngResponse] = await Promise.all([
       injectProfilePhoto([...validFields]),
@@ -250,6 +266,22 @@ describe('POST /api/mobile/profile-photo-ingest', () => {
     expect(noFile.statusCode).toBe(400);
     expect(multipleFiles.statusCode).toBe(413);
     expect(mocks.scheduleIndexerRun).not.toHaveBeenCalled();
+  });
+
+  it('maps excess multipart fields to a bounded client error', async () => {
+    const response = await injectProfilePhoto([
+      validFields[0],
+      validFields[1],
+      { name: 'unexpected', value: 'extra' },
+      validFields[2]
+    ]);
+
+    expect(response.statusCode).toBe(413);
+    expect(response.json()).toMatchObject({
+      success: false,
+      error: { code: 'PAYLOAD_TOO_LARGE' }
+    });
+    expect(mocks.findUnique).not.toHaveBeenCalled();
   });
 
   it('rejects MIME-spoofed and mismatched image payloads', async () => {

--- a/backend/src/routes/registerMobileIngestRoutes.test.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.test.ts
@@ -1,0 +1,220 @@
+import Fastify, { FastifyInstance } from 'fastify';
+import multipart from '@fastify/multipart';
+import { mkdtemp, readdir, readFile, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  scheduleIndexerRun: vi.fn(),
+  triggerIndexerRun: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../db/client.js', () => ({
+  prisma: {
+    account: { findUnique: mocks.findUnique }
+  }
+}));
+
+vi.mock('../services/indexerService.js', () => ({
+  scheduleIndexerRun: mocks.scheduleIndexerRun,
+  triggerIndexerRun: mocks.triggerIndexerRun
+}));
+
+import { registerMobileIngestRoutes } from './registerMobileIngestRoutes.js';
+
+const originalCrawlOutputDir = process.env.CRAWL_OUTPUT_DIR;
+const originalMobileIngestToken = process.env.MOBILE_INGEST_TOKEN;
+const originalNodeEnv = process.env.NODE_ENV;
+let app: FastifyInstance | null = null;
+let sourceRoot: string | null = null;
+
+function multipartPayload(parts: Array<
+  | { name: string; value: string }
+  | { name: string; filename: string; contentType: string; data: Buffer }
+>): { body: Buffer; contentType: string } {
+  const boundary = '----fromistargram-profile-photo-test';
+  const chunks: Buffer[] = [];
+
+  for (const part of parts) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`));
+    if ('filename' in part) {
+      chunks.push(Buffer.from(
+        `Content-Disposition: form-data; name="${part.name}"; filename="${part.filename}"\r\n` +
+        `Content-Type: ${part.contentType}\r\n\r\n`
+      ));
+      chunks.push(part.data, Buffer.from('\r\n'));
+    } else {
+      chunks.push(Buffer.from(
+        `Content-Disposition: form-data; name="${part.name}"\r\n\r\n${part.value}\r\n`
+      ));
+    }
+  }
+
+  chunks.push(Buffer.from(`--${boundary}--\r\n`));
+  return {
+    body: Buffer.concat(chunks),
+    contentType: `multipart/form-data; boundary=${boundary}`
+  };
+}
+
+async function injectProfilePhoto(parts: Parameters<typeof multipartPayload>[0], authenticated = true) {
+  const payload = multipartPayload(parts);
+  return app!.inject({
+    method: 'POST',
+    url: '/api/mobile/profile-photo-ingest',
+    headers: {
+      'content-type': payload.contentType,
+      ...(authenticated ? { authorization: 'Bearer test-mobile-token' } : {})
+    },
+    payload: payload.body
+  });
+}
+
+beforeEach(async () => {
+  sourceRoot = await mkdtemp(path.join(os.tmpdir(), 'fromistargram-profile-ingest-'));
+  process.env.CRAWL_OUTPUT_DIR = sourceRoot;
+  process.env.MOBILE_INGEST_TOKEN = 'test-mobile-token';
+  process.env.NODE_ENV = 'test';
+  mocks.findUnique.mockReset();
+  mocks.findUnique.mockResolvedValue({ id: 'test_user' });
+  mocks.scheduleIndexerRun.mockReset();
+  mocks.triggerIndexerRun.mockReset().mockResolvedValue(undefined);
+
+  app = Fastify({ logger: false });
+  await app.register(multipart);
+  await app.register(registerMobileIngestRoutes);
+});
+
+afterEach(async () => {
+  await app?.close();
+  app = null;
+  if (sourceRoot) {
+    await rm(sourceRoot, { recursive: true, force: true });
+    sourceRoot = null;
+  }
+
+  if (originalCrawlOutputDir === undefined) delete process.env.CRAWL_OUTPUT_DIR;
+  else process.env.CRAWL_OUTPUT_DIR = originalCrawlOutputDir;
+  if (originalMobileIngestToken === undefined) delete process.env.MOBILE_INGEST_TOKEN;
+  else process.env.MOBILE_INGEST_TOKEN = originalMobileIngestToken;
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+});
+
+describe('POST /api/mobile/profile-photo-ingest', () => {
+  const validFields = [
+    { name: 'accountName', value: ' @Test_User ' },
+    { name: 'capturedAt', value: '2026-08-09T12:34:56+09:00' },
+    {
+      name: 'file',
+      filename: 'avatar.JPG',
+      contentType: 'image/jpeg',
+      data: Buffer.from('profile-photo-bytes')
+    }
+  ] as const;
+
+  it('requires mobile ingest authentication', async () => {
+    const response = await injectProfilePhoto([...validFields], false);
+
+    expect(response.statusCode).toBe(401);
+    expect(mocks.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('writes one normalized profile photo without post artifacts and awaits indexing in tests', async () => {
+    const response = await injectProfilePhoto([...validFields]);
+
+    expect(response.statusCode).toBe(200);
+    expect(mocks.findUnique).toHaveBeenCalledWith({
+      where: { id: 'test_user' },
+      select: { id: true }
+    });
+    expect(mocks.scheduleIndexerRun).toHaveBeenCalledWith('mobile-profile-photo-ingest');
+    expect(mocks.triggerIndexerRun).toHaveBeenCalledWith('mobile-profile-photo-ingest');
+
+    const accountDir = path.join(sourceRoot!, 'test_user');
+    const files = await readdir(accountDir);
+    expect(files).toEqual(['2026-08-09_03-34-56_UTC_profile_pic.jpg']);
+    expect(await readFile(path.join(accountDir, files[0]))).toEqual(Buffer.from('profile-photo-bytes'));
+    expect(response.json()).toMatchObject({
+      success: true,
+      data: {
+        accountId: 'test_user',
+        uploadedAt: '2026-08-09T03:34:56.000Z',
+        fileCount: 1,
+        shouldRunIndexer: true,
+        archiveUrl: 'http://localhost:80/api/media/test_user/2026-08-09_03-34-56_UTC_profile_pic.jpg'
+      }
+    });
+  });
+
+  it('is idempotent for identical bytes and rejects conflicting bytes at the same second', async () => {
+    const first = await injectProfilePhoto([...validFields]);
+    const retry = await injectProfilePhoto([...validFields]);
+    const conflict = await injectProfilePhoto([
+      ...validFields.slice(0, 2),
+      {
+        name: 'file',
+        filename: 'avatar.jpg',
+        contentType: 'image/jpeg',
+        data: Buffer.from('different-profile-photo-bytes')
+      }
+    ]);
+
+    expect(first.statusCode).toBe(200);
+    expect(retry.statusCode).toBe(200);
+    expect(conflict.statusCode).toBe(409);
+    expect(conflict.json()).toMatchObject({
+      success: false,
+      error: { code: 'CONFLICT' }
+    });
+    expect(mocks.scheduleIndexerRun).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects zero or multiple files', async () => {
+    const noFile = await injectProfilePhoto(validFields.slice(0, 2));
+    const multipleFiles = await injectProfilePhoto([
+      ...validFields,
+      {
+        name: 'files',
+        filename: 'second.png',
+        contentType: 'image/png',
+        data: Buffer.from('second')
+      }
+    ]);
+
+    expect(noFile.statusCode).toBe(400);
+    expect(multipleFiles.statusCode).toBe(400);
+    expect(mocks.scheduleIndexerRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-images, invalid capturedAt, unknown accounts, and traversal-shaped names', async () => {
+    const video = await injectProfilePhoto([
+      ...validFields.slice(0, 2),
+      { name: 'file', filename: 'clip.mp4', contentType: 'video/mp4', data: Buffer.from('video') }
+    ]);
+    const invalidDate = await injectProfilePhoto([
+      validFields[0],
+      { name: 'capturedAt', value: '2026-08-09' },
+      validFields[2]
+    ]);
+    mocks.findUnique.mockResolvedValueOnce(null);
+    const unknown = await injectProfilePhoto([
+      { name: 'accountName', value: '@missing' },
+      validFields[1],
+      validFields[2]
+    ]);
+    const traversal = await injectProfilePhoto([
+      { name: 'accountName', value: '../escape' },
+      validFields[1],
+      validFields[2]
+    ]);
+
+    expect(video.statusCode).toBe(400);
+    expect(invalidDate.statusCode).toBe(400);
+    expect(unknown.statusCode).toBe(404);
+    expect(traversal.statusCode).toBe(400);
+    expect(mocks.scheduleIndexerRun).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/registerMobileIngestRoutes.test.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.test.ts
@@ -29,6 +29,18 @@ const originalMobileIngestToken = process.env.MOBILE_INGEST_TOKEN;
 const originalNodeEnv = process.env.NODE_ENV;
 let app: FastifyInstance | null = null;
 let sourceRoot: string | null = null;
+const JPEG_A = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.from('profile-photo-a')
+]);
+const JPEG_B = Buffer.concat([
+  Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+  Buffer.from('profile-photo-b')
+]);
+const PNG_A = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('profile-photo-png')
+]);
 
 function multipartPayload(parts: Array<
   | { name: string; value: string }
@@ -111,7 +123,7 @@ describe('POST /api/mobile/profile-photo-ingest', () => {
       name: 'file',
       filename: 'avatar.JPG',
       contentType: 'image/jpeg',
-      data: Buffer.from('profile-photo-bytes')
+      data: JPEG_A
     }
   ] as const;
 
@@ -136,8 +148,9 @@ describe('POST /api/mobile/profile-photo-ingest', () => {
     const accountDir = path.join(sourceRoot!, 'test_user');
     const files = await readdir(accountDir);
     expect(files).toEqual(['2026-08-09_03-34-56_UTC_profile_pic.jpg']);
-    expect(await readFile(path.join(accountDir, files[0]))).toEqual(Buffer.from('profile-photo-bytes'));
-    expect(response.json()).toMatchObject({
+    expect(await readFile(path.join(accountDir, files[0]))).toEqual(JPEG_A);
+    const responseBody = response.json();
+    expect(responseBody).toMatchObject({
       success: true,
       data: {
         accountId: 'test_user',
@@ -147,6 +160,8 @@ describe('POST /api/mobile/profile-photo-ingest', () => {
         archiveUrl: 'http://localhost:80/api/media/test_user/2026-08-09_03-34-56_UTC_profile_pic.jpg'
       }
     });
+    expect(responseBody.data).not.toHaveProperty('savedFiles');
+    expect(JSON.stringify(responseBody)).not.toContain(sourceRoot!);
   });
 
   it('is idempotent for identical bytes and rejects conflicting bytes at the same second', async () => {
@@ -158,7 +173,7 @@ describe('POST /api/mobile/profile-photo-ingest', () => {
         name: 'file',
         filename: 'avatar.jpg',
         contentType: 'image/jpeg',
-        data: Buffer.from('different-profile-photo-bytes')
+        data: JPEG_B
       }
     ]);
 
@@ -170,6 +185,54 @@ describe('POST /api/mobile/profile-photo-ingest', () => {
       error: { code: 'CONFLICT' }
     });
     expect(mocks.scheduleIndexerRun).toHaveBeenCalledTimes(2);
+  });
+
+  it('is idempotent across filename extensions and rejects a different format at the same second', async () => {
+    const first = await injectProfilePhoto([...validFields]);
+    const renamedRetry = await injectProfilePhoto([
+      ...validFields.slice(0, 2),
+      {
+        name: 'file',
+        filename: 'avatar.jpeg',
+        contentType: 'image/jpg',
+        data: JPEG_A
+      }
+    ]);
+    const crossFormatConflict = await injectProfilePhoto([
+      ...validFields.slice(0, 2),
+      {
+        name: 'file',
+        filename: 'avatar.png',
+        contentType: 'image/png',
+        data: PNG_A
+      }
+    ]);
+
+    expect(first.statusCode).toBe(200);
+    expect(renamedRetry.statusCode).toBe(200);
+    expect(crossFormatConflict.statusCode).toBe(409);
+    expect(await readdir(path.join(sourceRoot!, 'test_user'))).toEqual([
+      '2026-08-09_03-34-56_UTC_profile_pic.jpg'
+    ]);
+  });
+
+  it('serializes concurrent writes for one logical account timestamp', async () => {
+    const [jpegResponse, pngResponse] = await Promise.all([
+      injectProfilePhoto([...validFields]),
+      injectProfilePhoto([
+        ...validFields.slice(0, 2),
+        {
+          name: 'file',
+          filename: 'avatar.png',
+          contentType: 'image/png',
+          data: PNG_A
+        }
+      ])
+    ]);
+
+    expect([jpegResponse.statusCode, pngResponse.statusCode].sort()).toEqual([200, 409]);
+    expect((await readdir(path.join(sourceRoot!, 'test_user'))).length).toBe(1);
+    expect(mocks.scheduleIndexerRun).toHaveBeenCalledTimes(1);
   });
 
   it('rejects zero or multiple files', async () => {
@@ -185,7 +248,51 @@ describe('POST /api/mobile/profile-photo-ingest', () => {
     ]);
 
     expect(noFile.statusCode).toBe(400);
-    expect(multipleFiles.statusCode).toBe(400);
+    expect(multipleFiles.statusCode).toBe(413);
+    expect(mocks.scheduleIndexerRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects MIME-spoofed and mismatched image payloads', async () => {
+    const spoofed = await injectProfilePhoto([
+      ...validFields.slice(0, 2),
+      {
+        name: 'file',
+        filename: 'fake.jpg',
+        contentType: 'image/jpeg',
+        data: Buffer.from('not-an-image')
+      }
+    ]);
+    const mismatched = await injectProfilePhoto([
+      ...validFields.slice(0, 2),
+      {
+        name: 'file',
+        filename: 'avatar.jpg',
+        contentType: 'image/jpeg',
+        data: PNG_A
+      }
+    ]);
+
+    expect(spoofed.statusCode).toBe(400);
+    expect(mismatched.statusCode).toBe(400);
+    expect(mocks.scheduleIndexerRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects a profile image larger than the route-specific 30MB limit', async () => {
+    const oversized = Buffer.concat([
+      Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+      Buffer.alloc(30 * 1024 * 1024, 1)
+    ]);
+    const response = await injectProfilePhoto([
+      ...validFields.slice(0, 2),
+      {
+        name: 'file',
+        filename: 'oversized.jpg',
+        contentType: 'image/jpeg',
+        data: oversized
+      }
+    ]);
+
+    expect(response.statusCode).toBe(413);
     expect(mocks.scheduleIndexerRun).not.toHaveBeenCalled();
   });
 

--- a/backend/src/routes/registerMobileIngestRoutes.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.ts
@@ -33,7 +33,7 @@ type ParsedPostedAt = {
 };
 
 const PROFILE_PHOTO_MAX_BYTES = 30 * 1024 * 1024;
-const PROFILE_PHOTO_EXTENSIONS = new Set(['.jpg', '.png', '.gif', '.webp']);
+const PROFILE_PHOTO_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
 const profilePhotoWriteQueues = new Map<string, Promise<void>>();
 
 async function withProfilePhotoWriteLock<T>(
@@ -437,6 +437,7 @@ async function readProfilePhotoIngestForm(request: FastifyRequest): Promise<{
     if (
       code === 'FST_REQ_FILE_TOO_LARGE' ||
       code === 'FST_FILES_LIMIT' ||
+      code === 'FST_FIELDS_LIMIT' ||
       code === 'FST_PARTS_LIMIT'
     ) {
       throw new IngestClientError(

--- a/backend/src/routes/registerMobileIngestRoutes.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.ts
@@ -131,6 +131,29 @@ function parsePostedAt(value?: string): ParsedPostedAt | null {
   };
 }
 
+const ISO_DATETIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-](\d{2}):(\d{2}))$/;
+
+function parseCapturedAt(value?: string): ParsedPostedAt | null {
+  const match = value?.match(ISO_DATETIME_PATTERN);
+  if (!value || !match) {
+    return null;
+  }
+
+  if (!buildUtcDate(match[1], match[2], match[3], match[4], match[5], match[6])) {
+    return null;
+  }
+
+  if (match[7] !== 'Z') {
+    const offsetHours = Number(match[8]);
+    const offsetMinutes = Number(match[9]);
+    if (offsetHours > 14 || offsetMinutes > 59 || (offsetHours === 14 && offsetMinutes !== 0)) {
+      return null;
+    }
+  }
+
+  return parsePostedAt(value);
+}
+
 function buildUtcDate(
   year: string,
   month: string,
@@ -343,6 +366,94 @@ async function readMobileIngestForm(request: FastifyRequest): Promise<{
   return { files, accountName, uploadedAt, contentType, caption, highlightTitle };
 }
 
+async function readProfilePhotoIngestForm(request: FastifyRequest): Promise<{
+  files: BufferedUploadFile[];
+  accountName: string | null;
+  capturedAt?: string;
+}> {
+  const files: BufferedUploadFile[] = [];
+  let accountName: string | null = null;
+  let capturedAt: string | undefined;
+
+  for await (const part of request.parts()) {
+    if (part.type === 'file') {
+      if (part.fieldname !== 'file' && part.fieldname !== 'files') {
+        throw new IngestClientError('Unexpected file field name');
+      }
+
+      files.push({
+        file: part as MultipartFile,
+        buffer: await part.toBuffer()
+      });
+      continue;
+    }
+
+    const value = (part as { value?: string }).value ?? '';
+    if (part.fieldname === 'accountName') {
+      accountName = normalizeAccountName(value);
+    } else if (part.fieldname === 'capturedAt') {
+      capturedAt = value;
+    }
+  }
+
+  return { files, accountName, capturedAt };
+}
+
+function resolveProfilePhotoExtension(file: MultipartFile): string {
+  const originalExtension = path.extname(file.filename ?? '').toLowerCase();
+  const allowedByMime: Record<string, string[]> = {
+    'image/jpeg': ['.jpg', '.jpeg'],
+    'image/jpg': ['.jpg', '.jpeg'],
+    'image/png': ['.png'],
+    'image/gif': ['.gif'],
+    'image/webp': ['.webp']
+  };
+  const allowedExtensions = allowedByMime[file.mimetype];
+
+  if (!allowedExtensions) {
+    throw new IngestClientError('Profile photo must be an image');
+  }
+
+  return allowedExtensions.includes(originalExtension) ? originalExtension : allowedExtensions[0];
+}
+
+async function saveProfilePhoto(input: {
+  file: BufferedUploadFile;
+  accountId: string;
+  capturedAt: ParsedPostedAt;
+  request: FastifyRequest;
+}) {
+  const validation = validateFileType(input.file.file.mimetype, input.file.buffer.length);
+  if (!validation.valid) {
+    throw new IngestClientError(validation.error || 'Invalid file');
+  }
+
+  const extension = resolveProfilePhotoExtension(input.file.file);
+  const filename = `${input.capturedAt.timestampBase}_UTC_profile_pic${extension}`;
+  const sourceDir = getSourcePath(input.accountId, input.capturedAt.date);
+  const filepath = path.join(sourceDir, filename);
+
+  await mkdir(sourceDir, { recursive: true });
+  await writeSourceFileAllowingIdenticalOverwrite(filepath, input.file.buffer);
+
+  const apiBaseUrl = getApiBaseUrl(input.request);
+  const archiveUrl = apiBaseUrl
+    ? `${apiBaseUrl}/api/media/${encodeURIComponent(input.accountId)}/${encodeURIComponent(filename)}`
+    : null;
+
+  return {
+    storageTarget: 'SOURCE' as StorageTarget,
+    accountId: input.accountId,
+    postId: null,
+    archiveUrl,
+    uploadedAt: input.capturedAt.date.toISOString(),
+    fileCount: 1,
+    uploadBatchId: null,
+    savedFiles: [{ filename, filepath }],
+    shouldRunIndexer: true
+  };
+}
+
 async function saveToShared(input: {
   files: BufferedUploadFile[];
   accountName: string | null;
@@ -544,6 +655,63 @@ async function saveToHighlight(input: {
 }
 
 export async function registerMobileIngestRoutes(app: FastifyInstance): Promise<void> {
+  app.post('/api/mobile/profile-photo-ingest', async (request, reply) => {
+    if (!requireMobileIngestAuth(request, reply)) {
+      return reply;
+    }
+
+    try {
+      const input = await readProfilePhotoIngestForm(request);
+      if (input.files.length !== 1) {
+        return sendError(reply, 'Exactly one image file is required', 400, 'BAD_REQUEST');
+      }
+
+      if (!input.accountName || input.accountName.length > 128 || input.accountName.includes('..')) {
+        return sendError(reply, 'A valid accountName is required', 400, 'BAD_REQUEST');
+      }
+
+      const capturedAt = parseCapturedAt(input.capturedAt);
+      if (!capturedAt) {
+        return sendError(
+          reply,
+          'capturedAt must be a valid ISO 8601 datetime',
+          400,
+          'BAD_REQUEST'
+        );
+      }
+
+      const existingAccount = await prisma.account.findUnique({
+        where: { id: input.accountName },
+        select: { id: true }
+      });
+      if (!existingAccount) {
+        return sendError(reply, 'Account not found for profile photo upload', 404, 'NOT_FOUND');
+      }
+
+      const data = await saveProfilePhoto({
+        file: input.files[0],
+        accountId: existingAccount.id,
+        capturedAt,
+        request
+      });
+
+      scheduleIndexerRun('mobile-profile-photo-ingest');
+      if (process.env.NODE_ENV === 'test') {
+        await triggerIndexerRun('mobile-profile-photo-ingest');
+      }
+
+      return sendSuccess(reply, data);
+    } catch (error) {
+      request.log.error(error, 'Mobile profile photo ingest failed');
+      const message = error instanceof Error ? error.message : 'Mobile profile photo ingest failed';
+      if (error instanceof IngestClientError) {
+        return sendError(reply, message, error.statusCode, error.code);
+      }
+
+      return sendError(reply, 'Mobile profile photo ingest failed');
+    }
+  });
+
   app.post('/api/mobile/instagram-ingest', async (request, reply) => {
     if (!requireMobileIngestAuth(request, reply)) {
       return reply;

--- a/backend/src/routes/registerMobileIngestRoutes.ts
+++ b/backend/src/routes/registerMobileIngestRoutes.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { MultipartFile } from '@fastify/multipart';
-import { mkdir, readFile, stat, writeFile } from 'fs/promises';
+import { mkdir, readFile, readdir, realpath, stat, writeFile } from 'fs/promises';
 import path from 'path';
 import { randomUUID } from 'node:crypto';
 import { prisma } from '../db/client.js';
@@ -16,6 +16,7 @@ import {
 } from '../utils/fileUpload.js';
 import { formatDateToYYYYMMDD } from '../utils/dateFormat.js';
 import { sendError, sendSuccess } from '../utils/response.js';
+import { resolveSourceRoot } from '../utils/sourceRoot.js';
 
 type MobileIngestContentType = 'POST' | 'STORY' | 'REEL' | 'HIGHLIGHT';
 type SourceUploadType = 'Post' | 'Story';
@@ -30,6 +31,31 @@ type ParsedPostedAt = {
   date: Date;
   timestampBase: string;
 };
+
+const PROFILE_PHOTO_MAX_BYTES = 30 * 1024 * 1024;
+const PROFILE_PHOTO_EXTENSIONS = new Set(['.jpg', '.png', '.gif', '.webp']);
+const profilePhotoWriteQueues = new Map<string, Promise<void>>();
+
+async function withProfilePhotoWriteLock<T>(
+  logicalKey: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = profilePhotoWriteQueues.get(logicalKey) ?? Promise.resolve();
+  const result = previous.catch(() => undefined).then(operation);
+  const settled = result.then(
+    () => undefined,
+    () => undefined
+  );
+  profilePhotoWriteQueues.set(logicalKey, settled);
+
+  try {
+    return await result;
+  } finally {
+    if (profilePhotoWriteQueues.get(logicalKey) === settled) {
+      profilePhotoWriteQueues.delete(logicalKey);
+    }
+  }
+}
 
 class IngestClientError extends Error {
   readonly statusCode: number;
@@ -375,46 +401,97 @@ async function readProfilePhotoIngestForm(request: FastifyRequest): Promise<{
   let accountName: string | null = null;
   let capturedAt: string | undefined;
 
-  for await (const part of request.parts()) {
-    if (part.type === 'file') {
-      if (part.fieldname !== 'file' && part.fieldname !== 'files') {
-        throw new IngestClientError('Unexpected file field name');
+  try {
+    for await (const part of request.parts({
+      limits: {
+        files: 1,
+        fileSize: PROFILE_PHOTO_MAX_BYTES,
+        fields: 2,
+        parts: 3
+      }
+    })) {
+      if (part.type === 'file') {
+        if (part.fieldname !== 'file' && part.fieldname !== 'files') {
+          throw new IngestClientError('Unexpected file field name');
+        }
+
+        files.push({
+          file: part as MultipartFile,
+          buffer: await part.toBuffer()
+        });
+        continue;
       }
 
-      files.push({
-        file: part as MultipartFile,
-        buffer: await part.toBuffer()
-      });
-      continue;
+      const value = (part as { value?: string }).value ?? '';
+      if (part.fieldname === 'accountName') {
+        accountName = normalizeAccountName(value);
+      } else if (part.fieldname === 'capturedAt') {
+        capturedAt = value;
+      }
     }
-
-    const value = (part as { value?: string }).value ?? '';
-    if (part.fieldname === 'accountName') {
-      accountName = normalizeAccountName(value);
-    } else if (part.fieldname === 'capturedAt') {
-      capturedAt = value;
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String(error.code)
+        : '';
+    if (
+      code === 'FST_REQ_FILE_TOO_LARGE' ||
+      code === 'FST_FILES_LIMIT' ||
+      code === 'FST_PARTS_LIMIT'
+    ) {
+      throw new IngestClientError(
+        'Exactly one profile image up to 30MB is required',
+        413,
+        'PAYLOAD_TOO_LARGE'
+      );
     }
+    throw error;
   }
 
   return { files, accountName, capturedAt };
 }
 
-function resolveProfilePhotoExtension(file: MultipartFile): string {
-  const originalExtension = path.extname(file.filename ?? '').toLowerCase();
-  const allowedByMime: Record<string, string[]> = {
-    'image/jpeg': ['.jpg', '.jpeg'],
-    'image/jpg': ['.jpg', '.jpeg'],
-    'image/png': ['.png'],
-    'image/gif': ['.gif'],
-    'image/webp': ['.webp']
-  };
-  const allowedExtensions = allowedByMime[file.mimetype];
-
-  if (!allowedExtensions) {
-    throw new IngestClientError('Profile photo must be an image');
+function detectProfilePhotoType(buffer: Buffer): {
+  extension: '.jpg' | '.png' | '.gif' | '.webp';
+  mimeType: string;
+} {
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return { extension: '.jpg', mimeType: 'image/jpeg' };
+  }
+  if (
+    buffer.length >= 8 &&
+    buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+  ) {
+    return { extension: '.png', mimeType: 'image/png' };
+  }
+  if (
+    buffer.length >= 6 &&
+    (buffer.subarray(0, 6).toString('ascii') === 'GIF87a' ||
+      buffer.subarray(0, 6).toString('ascii') === 'GIF89a')
+  ) {
+    return { extension: '.gif', mimeType: 'image/gif' };
+  }
+  if (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    buffer.subarray(8, 12).toString('ascii') === 'WEBP'
+  ) {
+    return { extension: '.webp', mimeType: 'image/webp' };
   }
 
-  return allowedExtensions.includes(originalExtension) ? originalExtension : allowedExtensions[0];
+  throw new IngestClientError('Profile photo bytes are not a supported image');
+}
+
+function resolveProfilePhotoType(file: BufferedUploadFile): {
+  extension: '.jpg' | '.png' | '.gif' | '.webp';
+  mimeType: string;
+} {
+  const detected = detectProfilePhotoType(file.buffer);
+  const declaredMime = file.file.mimetype === 'image/jpg' ? 'image/jpeg' : file.file.mimetype;
+  if (declaredMime !== detected.mimeType) {
+    throw new IngestClientError('Profile photo MIME type does not match its file contents');
+  }
+  return detected;
 }
 
 async function saveProfilePhoto(input: {
@@ -423,22 +500,58 @@ async function saveProfilePhoto(input: {
   capturedAt: ParsedPostedAt;
   request: FastifyRequest;
 }) {
-  const validation = validateFileType(input.file.file.mimetype, input.file.buffer.length);
+  const detectedType = resolveProfilePhotoType(input.file);
+  const validation = validateFileType(detectedType.mimeType, input.file.buffer.length);
   if (!validation.valid) {
     throw new IngestClientError(validation.error || 'Invalid file');
   }
 
-  const extension = resolveProfilePhotoExtension(input.file.file);
-  const filename = `${input.capturedAt.timestampBase}_UTC_profile_pic${extension}`;
+  const filenamePrefix = `${input.capturedAt.timestampBase}_UTC_profile_pic`;
   const sourceDir = getSourcePath(input.accountId, input.capturedAt.date);
-  const filepath = path.join(sourceDir, filename);
-
   await mkdir(sourceDir, { recursive: true });
-  await writeSourceFileAllowingIdenticalOverwrite(filepath, input.file.buffer);
+
+  const [realSourceRoot, realSourceDir] = await Promise.all([
+    realpath(resolveSourceRoot()),
+    realpath(sourceDir)
+  ]);
+  if (
+    realSourceDir !== realSourceRoot &&
+    !realSourceDir.startsWith(`${realSourceRoot}${path.sep}`)
+  ) {
+    throw new IngestClientError('Profile photo target escapes the source root');
+  }
+
+  const logicalKey = `${input.accountId}:${input.capturedAt.timestampBase}`;
+  const saved = await withProfilePhotoWriteLock(logicalKey, async () => {
+    const existingProfileFiles = (await readdir(sourceDir)).filter((name) => {
+      return (
+        name.startsWith(`${filenamePrefix}.`) &&
+        PROFILE_PHOTO_EXTENSIONS.has(path.extname(name).toLowerCase())
+      );
+    });
+
+    if (existingProfileFiles.length > 1) {
+      throw new IngestClientError(
+        `Multiple profile photos already exist for timestamp: ${input.capturedAt.timestampBase}`,
+        409,
+        'CONFLICT'
+      );
+    }
+
+    const filename =
+      existingProfileFiles[0] ?? `${filenamePrefix}${detectedType.extension}`;
+    const filepath = path.join(sourceDir, filename);
+    if (existingProfileFiles.length === 1) {
+      await ensureSourceFileCanBeWritten(filepath, input.file.buffer);
+    } else {
+      await writeSourceFileAllowingIdenticalOverwrite(filepath, input.file.buffer);
+    }
+    return { filename };
+  });
 
   const apiBaseUrl = getApiBaseUrl(input.request);
   const archiveUrl = apiBaseUrl
-    ? `${apiBaseUrl}/api/media/${encodeURIComponent(input.accountId)}/${encodeURIComponent(filename)}`
+    ? `${apiBaseUrl}/api/media/${encodeURIComponent(input.accountId)}/${encodeURIComponent(saved.filename)}`
     : null;
 
   return {
@@ -449,7 +562,7 @@ async function saveProfilePhoto(input: {
     uploadedAt: input.capturedAt.date.toISOString(),
     fileCount: 1,
     uploadBatchId: null,
-    savedFiles: [{ filename, filepath }],
+    filename: saved.filename,
     shouldRunIndexer: true
   };
 }


### PR DESCRIPTION
## Summary
- add authenticated `POST /api/mobile/profile-photo-ingest` for one profile image
- save images with the scanner-recognized UTC profile filename under an existing account source directory
- make identical retries idempotent, reject conflicting bytes, invalid accounts/dates/media, and traversal input
- schedule the indexer after a successful write

## Verification
- `pnpm --filter @fromistargram/backend test` — 27 passed
- `pnpm --filter @fromistargram/backend lint` — passed
- `pnpm --filter @fromistargram/backend build` — passed
- `git diff --check` — passed

## App dependency
Consumed by `angelos0424/insta-backup` profile-photo sync. The app preserves local/gallery state if the upload fails and retries on the next button press.